### PR TITLE
translations: Use install(FILES ...) instead of install(DIRECTORY ...)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -231,4 +231,4 @@ install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/screengrab.desktop" DESTINATION share
 # install pixmap
 install(FILES "${CMAKE_CURRENT_SOURCE_DIR}/img/screengrab.png" DESTINATION share/pixmaps)
 # install translations
-install(DIRECTORY ${SCREENGRAB_QMS} DESTINATION share/screengrab/translations)
+install(FILES ${SCREENGRAB_QMS} DESTINATION share/screengrab/translations)


### PR DESCRIPTION
SCREENGRAB_QMS holds a list of files not directories.
It succeeds because CMake treats each file as being it's directory. But it
fails when for some reason SCREENGRAB_QMS is reevaluated.
Example:
    cmake .. && make && sudo make install
    cmake -DCMAKE_INSTALL_PREFIX=/usr/local ..

The later call to cmake fails.
