### PR TITLE
Drops Qt foreach

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,9 +3,9 @@ cmake_minimum_required(VERSION 3.0.2 FATAL_ERROR)
 # set project's name
 project(screengrab)
 
-find_package(Qt5Widgets 5.2.0 REQUIRED)
-find_package(Qt5X11Extras 5.2.0 REQUIRED)
-find_package(Qt5Network 5.2.0 REQUIRED)
+find_package(Qt5Widgets 5.7.1 REQUIRED)
+find_package(Qt5X11Extras 5.7.1 REQUIRED)
+find_package(Qt5Network 5.7.1 REQUIRED)
 find_package(KF5WindowSystem REQUIRED)
 
 # for translations
@@ -64,7 +64,10 @@ elseif(NOT SCREENGRAB_VERSION_DEV)
     set(VERSION "${SCREENGRAB_VERSION}")
 endif(SCREENGRAB_VERSION_DEV)
 
-add_definitions(-DVERSION="${VERSION}")
+add_definitions(
+    -DVERSION="${VERSION}"
+    -DQT_NO_FOREACH
+)
 
 if(NOT CMAKE_BUILD_TYPE)
     set(CMAKE_BUILD_TYPE Release)

--- a/src/modules/extedit/extedit.cpp
+++ b/src/modules/extedit/extedit.cpp
@@ -88,6 +88,6 @@ void ExtEdit::createAppList()
     QMimeType mt = db.mimeTypeForFile(fileName);
     _appList = XdgDesktopFileCache::getApps(mt.name());
 
-    foreach (XdgDesktopFile *app, _appList)
+    for (XdgDesktopFile *app : qAsConst(_appList))
         _actionList << new XdgAction(app);
 }

--- a/src/modules/extedit/moduleextedit.cpp
+++ b/src/modules/extedit/moduleextedit.cpp
@@ -47,9 +47,9 @@ void ModuleExtEdit::init()
 QMenu* ModuleExtEdit::initModuleMenu()
 {
     QMenu *menu = new QMenu(QObject::tr("Edit in..."), 0);
-    QList<XdgAction*> actionsList = _extEdit->getActions();
+    const QList<XdgAction*> actionsList = _extEdit->getActions();
 
-    foreach (XdgAction *appAction, actionsList)
+    for (XdgAction *appAction : actionsList)
     {
         menu->addAction(appAction);
         appAction->disconnect(SIGNAL(triggered()));


### PR DESCRIPTION
Use range for instead. foreach will be deprecated and removed sooner or
later.
Qt 5.7.1 required. We use qAsConst.