### PR TITLE
Improve screengrab app behaviour

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -26,6 +26,10 @@ int main(int argc, char *argv[])
 {
     SingleApp scr(argc, argv, VERSION);
     scr.setApplicationVersion(VERSION);
+    scr.setOrganizationName(QStringLiteral("lxqt"));
+    scr.setOrganizationDomain(QStringLiteral("https://lxqt.org"));
+    scr.setApplicationName(QStringLiteral("screengrab"));
+    scr.setAttribute(Qt::AA_UseHighDpiPixmaps, true);
     Core *ScreenGrab = Core::instance();
     ScreenGrab->modules()->initModules();
     ScreenGrab->processCmdLineOpts(scr.arguments());


### PR DESCRIPTION
* Set OrganizationName to lxqt, refs #45
* Set OrganizationDomain to https://lxqt.org - we should do this for all
  of our applications
* Set ApplicationName to "screengrab" - while at it;
* Enable Qt::AA_UseHighDpiPixmaps