### PR TITLE
Cleanup and fixes

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -521,7 +521,7 @@ void Config::saveSettings()
 }
 
 void Config::saveScreenshotSettings()
-{
+{ // save the main window settings
     _settings->beginGroup("Base");
     _settings->setValue(QLatin1String(KEY_SCREENSHOT_TYPE_DEF), screenshotTypeToString(getDefScreenshotType()));
     _settings->setValue(KEY_NODECOR, getNoDecoration());
@@ -537,7 +537,7 @@ void Config::saveScreenshotSettings()
 
 // set default values
 void Config::setDefaultSettings()
-{ // save the main window settings
+{
     setSaveDir(getDirNameDefault());
     setSaveFileName(DEF_SAVE_NAME);
     setSaveFormat(DEF_SAVE_FORMAT);

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -100,12 +100,6 @@ public:
     ~Config();
 
     /**
-     * @brief Gets the configuration file for screengrab. It's
-     * inside the folder returned by getConfigDir().
-     */
-    static QString getConfigFile();
-
-    /**
      * @brief Gets the directory where to save the configuration files.
      * Does not end with '/'.
      */
@@ -120,6 +114,11 @@ public:
      * Save configuration data to conf file
      */
     void saveSettings();
+
+    /**
+     * Save screenshot settings to conf file
+     */
+    void saveScreenshotSettings();
 
     /**
      * Reset configuration data from default values
@@ -138,20 +137,12 @@ public:
     QString getSaveFormat();
     void setSaveFormat(QString format);
 
-    // default delay
-    quint8 getDefDelay();
-    void setDefDelay(quint8 sec);
-
     quint8 getDelay();
     void setDelay(quint8 sec);
 
     // configured default screenshot type
     int getDefScreenshotType();
     void setDefScreenshotType(const int type);
-
-    // current screenshot type
-    int getScreenshotType();
-    void setScreenshotType(const int type);
 
     quint8 getAutoCopyFilenameOnSaving();
     void setAutoCopyFilenameOnSaving(quint8 val);
@@ -192,7 +183,8 @@ public:
     void setRestoredWndSize(int w, int h);
     void saveWndSize();
 
-    // get default image save format
+    // get image save format(s)
+    QStringList getFormatIDs() const;
     int getDefaultFormatID();
     QString getDirNameDefault();
 
@@ -229,6 +221,9 @@ public:
     bool getFitInside();
     void setFitInside(bool val);
 
+    QRect getLastSelection();
+    void setLastSelection(QRect rect);
+
     static QString getSysLang();
 
     ShortcutManager* shortcuts();
@@ -260,8 +255,6 @@ private:
     QHash<QString, QVariant> _confData;
 
     ShortcutManager *_shortcuts;
-
-    QVector<QString> _imageFormats;
 
     int _scrNum; // screen num in session
     QDateTime _dateLastSaving;

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -54,6 +54,7 @@ Core::Core()
 
     _conf = Config::instance();
     _conf->loadSettings();
+    _lastSelectedArea = _conf->getLastSelection();
 
     _pixelMap = new QPixmap;
     _selector = 0;
@@ -144,6 +145,9 @@ void Core::sleep(int msec)
 
 void Core::coreQuit()
 {
+    _conf->setLastSelection(_lastSelectedArea);
+    _conf->saveScreenshotSettings();
+
     _conf->setRestoredWndSize(_wnd->width(), _wnd->height());
     _conf->saveWndSize();
 
@@ -183,7 +187,7 @@ void Core::screenShot(bool first)
     if (_firstScreen)
         _conf->updateLastSaveDate();
 
-    switch(_conf->getScreenshotType())
+    switch(_conf->getDefScreenshotType())
     {
     case Core::FullScreen:
     {
@@ -290,7 +294,7 @@ void Core::grabCursor(int offsetX, int offsetY)
 
 }
 
-void Core::sendSystemNotify(const StateNotifyMessage &notify)
+void Core::sendSystemNotify(const StateNotifyMessage& /*notify*/)
 {
     qDebug() << "Send system notification";
 }
@@ -511,7 +515,7 @@ void Core::processCmdLineOpts(const QStringList& arguments)
     // Check commandline parameters and set screenshot type
     for (int i=0; i < _screenTypeOpts.count(); ++i)
         if (_cmdLine.isSet(_screenTypeOpts.at(i)))
-            _conf->setScreenshotType(i);
+            _conf->setDefScreenshotType(i);
 
 #ifdef SG_EXT_UPLOADS
     /// FIXMA - In module interface need add the mthod for geting module cmdLine options

--- a/src/core/ui/configwidget.cpp
+++ b/src/core/ui/configwidget.cpp
@@ -39,21 +39,18 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     _ui->setupUi(this);
     conf = Config::instance();
 
-    connect(_ui->butSaveOpt, &QPushButton::clicked, this, &ConfigDialog::saveSettings);
+    connect(_ui->buttonBox->button(QDialogButtonBox::Save), &QPushButton::clicked, this, &ConfigDialog::saveSettings);
     connect(_ui->buttonBrowse, &QPushButton::clicked, this, &ConfigDialog::selectDir);
-    connect(_ui->butRestoreOpt, &QPushButton::clicked, this, &ConfigDialog::restoreDefaults);
+    connect(_ui->buttonBox->button(QDialogButtonBox::RestoreDefaults), &QPushButton::clicked, this, &ConfigDialog::restoreDefaults);
     connect(_ui->checkIncDate, &QCheckBox::toggled, this, &ConfigDialog::setVisibleDateTplEdit);
     connect(_ui->keyWidget, &QKeySequenceWidget::keySequenceAccepted, this, &ConfigDialog::acceptShortcut);
     connect(_ui->keyWidget, &QKeySequenceWidget::keyNotSupported, this, &ConfigDialog::keyNotSupported);
     connect(_ui->checkAutoSave, &QCheckBox::toggled, this, &ConfigDialog::setVisibleAutoSaveFirst);
-    connect(_ui->butCancel, &QPushButton::clicked, this, &ConfigDialog::reject);
+    connect(_ui->buttonBox->button(QDialogButtonBox::Cancel), &QPushButton::clicked, this, &ConfigDialog::reject);
     connect(_ui->treeKeys, &QTreeWidget::expanded, _ui->treeKeys, &QTreeWidget::clearSelection);
     connect(_ui->treeKeys, &QTreeWidget::collapsed, this, &ConfigDialog::collapsTreeKeys);
     connect(_ui->checkShowTray, &QCheckBox::toggled, this, &ConfigDialog::toggleCheckShowTray);
     connect(_ui->editDateTmeTpl, &QLineEdit::textEdited, this, &ConfigDialog::editDateTmeTpl);
-
-    void (QSpinBox::*delayChange)(int) = &QSpinBox::valueChanged;
-    connect(_ui->defDelay, delayChange, this, &ConfigDialog::changeDefDelay);
 
     void (QSpinBox::*timeToTray)(int) = &QSpinBox::valueChanged;
     connect(_ui->timeTrayMess, timeToTray, this, &ConfigDialog::changeTimeTrayMess);
@@ -73,13 +70,11 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     connect(_ui->cbxFormat, formatChabge, this, &ConfigDialog::changeFormatType);
 
     loadSettings();
-    changeDefDelay(conf->getDefDelay());
     setVisibleDateTplEdit(conf->getDateTimeInFilename());
 
     setVisibleAutoSaveFirst(conf->getAutoSave());
 
     _ui->listWidget->setCurrentRow(0);
-    _ui->tabMain->setCurrentIndex(0);
 
     editDateTmeTpl(conf->getDateTimeTpl());
 
@@ -148,12 +143,9 @@ void ConfigDialog::loadSettings()
     _ui->editDir->setText(conf->getSaveDir());
     _ui->editFileName->setText(conf->getSaveFileName());
 
-    _ui->cbxFormat->addItem("png");
-    _ui->cbxFormat->addItem("jpg");
+    _ui->cbxFormat->addItems(conf->getFormatIDs());
     _ui->cbxFormat->setCurrentIndex(conf->getDefaultFormatID());
 
-    _ui->defDelay->setValue(conf->getDefDelay());
-    _ui->cbxTypeScr->setCurrentIndex(conf->getDefScreenshotType());
     _ui->checkIncDate->setChecked(conf->getDateTimeInFilename());
     _ui->editDateTmeTpl->setText(conf->getDateTimeTpl());
     _ui->cbxCopyFileName->setCurrentIndex(conf->getAutoCopyFilenameOnSaving());
@@ -162,15 +154,12 @@ void ConfigDialog::loadSettings()
     _ui->cbxTrayMsg->setCurrentIndex(conf->getTrayMessages());
     changeTrayMsgType(_ui->cbxTrayMsg->currentIndex());
     _ui->timeTrayMess->setValue(conf->getTimeTrayMess());
-    _ui->checkAutoSave->setChecked(conf->getAutoSave());;
-    _ui->checkAutoSaveFirst->setChecked(conf->getAutoSaveFirst());;
-    _ui->checkZommMouseArea->setChecked(conf->getZoomAroundMouse());
-    _ui->cbxIncludeCursor->setChecked(conf->getIncludeCursor());
+    _ui->checkAutoSave->setChecked(conf->getAutoSave());
+    _ui->checkAutoSaveFirst->setChecked(conf->getAutoSaveFirst());
 
     _ui->checkInTray->setChecked(conf->getCloseInTray());
     _ui->checkAllowCopies->setChecked(conf->getAllowMultipleInstance());
 
-    _ui->checkNoDecorX11->setChecked(conf->getNoDecoration());
     _ui->checkShowTray->setChecked(conf->getShowTrayIcon());
     toggleCheckShowTray(conf->getShowTrayIcon());
 
@@ -201,17 +190,9 @@ void ConfigDialog::setVisibleAutoSaveFirst(bool status)
 void ConfigDialog::changeFormatType(int type)
 {
     if (type == 1)
-    {
-        _ui->slideImgQuality->setVisible(true);;
-        _ui->labImgQuality->setVisible(true);
-        _ui->labImgQualityCurrent->setVisible(true);;
-    }
+        _ui->groupQuality->setVisible(true);
     else
-    {
-        _ui->slideImgQuality->setVisible(false);
-        _ui->labImgQuality->setVisible(false);
-        _ui->labImgQualityCurrent->setVisible(false);;
-    }
+        _ui->groupQuality->setVisible(false);
 }
 
 
@@ -253,8 +234,6 @@ void ConfigDialog::saveSettings()
     conf->setSaveDir(_ui->editDir->text());
     conf->setSaveFileName(_ui->editFileName->text());
     conf->setSaveFormat(_ui->cbxFormat->currentText());
-    conf->setDefDelay(_ui->defDelay->value());
-    conf->setDefScreenshotType(_ui->cbxTypeScr->currentIndex());
     conf->setDateTimeInFilename(_ui->checkIncDate->isChecked());
     conf->setDateTimeTpl(_ui->editDateTmeTpl->text());
     conf->setAutoCopyFilenameOnSaving(_ui->cbxCopyFileName->currentIndex());
@@ -262,14 +241,11 @@ void ConfigDialog::saveSettings()
     conf->setAutoSaveFirst(_ui->checkAutoSaveFirst->isChecked());
     conf->setTrayMessages(_ui->cbxTrayMsg->currentIndex());
     conf->setCloseInTray(_ui->checkInTray->isChecked());
-    conf->setIncludeCursor(_ui->cbxIncludeCursor->isChecked());
-    conf->setZoomAroundMouse(_ui->checkZommMouseArea->isChecked());
     conf->setAllowMultipleInstance(_ui->checkAllowCopies->isChecked());
     conf->setTimeTrayMess(_ui->timeTrayMess->value());
     conf->setShowTrayIcon(_ui->checkShowTray->isChecked());
     conf->setImageQuality(_ui->slideImgQuality->value());
     conf->setEnableExtView(_ui->cbxEnableExtView->isChecked());
-    conf->setNoDecoration(_ui->checkNoDecorX11->isChecked());
     conf->setFitInside(_ui->checkFitInside->isChecked());
 
     // save shortcuts in shortcutmanager
@@ -297,7 +273,6 @@ void ConfigDialog::saveSettings()
 
     // update values of front-end settings
     conf->saveSettings();
-    conf->setDelay(conf->getDefDelay());
 
     // call save method on modeule's configwidgets'
     for (int i = 0; i < _moduleWidgetNames.count(); ++i)
@@ -347,12 +322,6 @@ void ConfigDialog::restoreDefaults()
         conf->saveSettings();
         QDialog::accept();
     }
-}
-
-void ConfigDialog::changeDefDelay(int val)
-{
-    if (val == 0)
-        _ui->defDelay->setSpecialValueText(tr("None"));
 }
 
 void ConfigDialog::changeTimeTrayMess(int sec)

--- a/src/core/ui/configwidget.h
+++ b/src/core/ui/configwidget.h
@@ -62,7 +62,6 @@ private slots:
     void setVisibleDateTplEdit(bool);
     void changeTrayMsgType(int type);
     void changeTimeTrayMess(int sec);
-    void changeDefDelay(int val);
     void setVisibleAutoSaveFirst(bool status);
     void changeFormatType(int type);
     void changeImgQualituSlider(int pos);

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -57,9 +57,6 @@
        <property name="textElideMode">
         <enum>Qt::ElideNone</enum>
        </property>
-       <property name="flow">
-        <enum>QListView::TopToBottom</enum>
-       </property>
        <property name="isWrapping" stdset="0">
         <bool>false</bool>
        </property>
@@ -109,369 +106,194 @@
         <number>0</number>
        </property>
        <widget class="QWidget" name="page_6">
-        <layout class="QVBoxLayout" name="verticalLayout_6">
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
+        <layout class="QVBoxLayout" name="verticalLayout">
+         <property name="spacing">
+          <number>5</number>
          </property>
          <item>
-          <widget class="QTabWidget" name="tabMain">
-           <property name="currentIndex">
-            <number>1</number>
+          <widget class="QGroupBox" name="groupBox">
+           <property name="title">
+            <string>Default save directory</string>
            </property>
-           <widget class="QWidget" name="tabSaving">
-            <attribute name="title">
-             <string>Saving</string>
-            </attribute>
-            <layout class="QVBoxLayout" name="verticalLayout_5">
-             <item>
-              <layout class="QVBoxLayout" name="verticalLayout">
-               <property name="spacing">
-                <number>4</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QLabel" name="labDirectory">
-                 <property name="text">
-                  <string>Default save directory:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QHBoxLayout" name="horizontalLayout_4">
-                 <item>
-                  <widget class="QLineEdit" name="editDir">
-                   <property name="toolTip">
-                    <string>Path to default selection dir for saving</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QPushButton" name="buttonBrowse">
-                   <property name="minimumSize">
-                    <size>
-                     <width>112</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Browse filesystem</string>
-                   </property>
-                   <property name="text">
-                    <string>Browse</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_14">
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_7">
-                 <item>
-                  <widget class="QLabel" name="labFilename">
-                   <property name="text">
-                    <string>Default filename:</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QLineEdit" name="editFileName">
-                   <property name="toolTip">
-                    <string>Default filename</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_9">
-                 <item>
-                  <widget class="QLabel" name="labFormat">
-                   <property name="text">
-                    <string>Format</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item>
-                  <widget class="QComboBox" name="cbxFormat">
-                   <property name="minimumSize">
-                    <size>
-                     <width>112</width>
-                     <height>0</height>
-                    </size>
-                   </property>
-                   <property name="toolTip">
-                    <string>Default saving image format</string>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout_11">
-               <property name="leftMargin">
-                <number>4</number>
-               </property>
-               <item>
-                <widget class="QLabel" name="labCopyFileName">
-                 <property name="text">
-                  <string>Copy file name to the clipboard when saving</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="cbxCopyFileName">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>Do not copy</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Copy file name only</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Copy full file path</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item>
-              <spacer name="verticalSpacer_5">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>82</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
-           <widget class="QWidget" name="tabScreenshot">
-            <attribute name="title">
-             <string>Screenshot</string>
-            </attribute>
-            <layout class="QGridLayout" name="gridLayout">
-             <item row="0" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QLabel" name="label">
-                 <property name="text">
-                  <string>Delay:</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QSpinBox" name="defDelay">
-                 <property name="toolTip">
-                  <string>Default delay before grabbing screen</string>
-                 </property>
-                 <property name="wrapping">
-                  <bool>false</bool>
-                 </property>
-                 <property name="suffix">
-                  <string> sec</string>
-                 </property>
-                 <property name="prefix">
-                  <string/>
-                 </property>
-                 <property name="maximum">
-                  <number>90</number>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_2">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <widget class="QCheckBox" name="checkNoDecorX11">
-                 <property name="text">
-                  <string>No window decoration</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="1" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_15">
-               <item>
-                <widget class="QLabel" name="labTypeScr_2">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="layoutDirection">
-                  <enum>Qt::LeftToRight</enum>
-                 </property>
-                 <property name="text">
-                  <string>Type: </string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="cbxTypeScr">
-                 <property name="enabled">
-                  <bool>true</bool>
-                 </property>
-                 <property name="toolTip">
-                  <string>Type of screenshot</string>
-                 </property>
-                 <property name="currentIndex">
-                  <number>0</number>
-                 </property>
-                 <item>
-                  <property name="text">
-                   <string>Full screen</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Window</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Screen area</string>
-                  </property>
-                 </item>
-                 <item>
-                  <property name="text">
-                   <string>Previous selection</string>
-                  </property>
-                 </item>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_3">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>118</width>
-                   <height>28</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-              </layout>
-             </item>
-             <item row="2" column="0">
-              <widget class="QLabel" name="labImgQuality">
-               <property name="text">
-                <string>Image quality</string>
-               </property>
-              </widget>
-             </item>
-             <item row="3" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_13">
-               <item>
-                <widget class="QSlider" name="slideImgQuality">
-                 <property name="toolTip">
-                  <string>Image quality (1 - small file, 100 - high quality)</string>
-                 </property>
-                 <property name="maximum">
-                  <number>100</number>
-                 </property>
-                 <property name="singleStep">
-                  <number>1</number>
-                 </property>
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLabel" name="labImgQualityCurrent">
-                 <property name="text">
-                  <string notr="true">Current</string>
-                 </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-             <item row="4" column="0" colspan="2">
-              <widget class="QCheckBox" name="cbxIncludeCursor">
-               <property name="text">
-                <string>Include mouse pointer</string>
-               </property>
-              </widget>
-             </item>
-             <item row="5" column="0" colspan="2">
-              <widget class="QCheckBox" name="checkZommMouseArea">
-               <property name="text">
-                <string>Zoom area around mouse in selection mode</string>
-               </property>
-              </widget>
-             </item>
-             <item row="6" column="1">
-              <spacer name="verticalSpacer">
-               <property name="orientation">
-                <enum>Qt::Vertical</enum>
-               </property>
-               <property name="sizeHint" stdset="0">
-                <size>
-                 <width>20</width>
-                 <height>117</height>
-                </size>
-               </property>
-              </spacer>
-             </item>
-            </layout>
-           </widget>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLineEdit" name="editDir">
+              <property name="toolTip">
+               <string>Path to default selection dir for saving</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QPushButton" name="buttonBrowse">
+              <property name="minimumSize">
+               <size>
+                <width>112</width>
+                <height>0</height>
+               </size>
+              </property>
+              <property name="toolTip">
+               <string>Browse filesystem</string>
+              </property>
+              <property name="text">
+               <string>Browse</string>
+              </property>
+             </widget>
+            </item>
+           </layout>
           </widget>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupBox_1">
+           <property name="title">
+            <string>Default file</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_5">
+            <item>
+             <layout class="QHBoxLayout" name="horizontalLayout_14">
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_7">
+                <item>
+                 <widget class="QLabel" name="labFilename">
+                  <property name="text">
+                   <string>Name:</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLineEdit" name="editFileName">
+                  <property name="toolTip">
+                   <string>Default filename</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item>
+               <layout class="QVBoxLayout" name="verticalLayout_9">
+                <item>
+                 <widget class="QLabel" name="labFormat">
+                  <property name="text">
+                   <string>Format</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QComboBox" name="cbxFormat">
+                  <property name="minimumSize">
+                   <size>
+                    <width>112</width>
+                    <height>0</height>
+                   </size>
+                  </property>
+                  <property name="toolTip">
+                   <string>Default saving image format</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+             </layout>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_11">
+           <property name="leftMargin">
+            <number>4</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="labCopyFileName">
+             <property name="text">
+              <string>Copy file name to the clipboard when saving</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QComboBox" name="cbxCopyFileName">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <item>
+              <property name="text">
+               <string>Do not copy</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Copy file name only</string>
+              </property>
+             </item>
+             <item>
+              <property name="text">
+               <string>Copy full file path</string>
+              </property>
+             </item>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QGroupBox" name="groupQuality">
+           <property name="title">
+            <string>Image quality</string>
+           </property>
+           <layout class="QHBoxLayout" name="horizontalLayout_2">
+            <item>
+             <widget class="QSlider" name="slideImgQuality">
+              <property name="toolTip">
+               <string>Image quality (1 - small file, 100 - high quality)</string>
+              </property>
+              <property name="maximum">
+               <number>100</number>
+              </property>
+              <property name="singleStep">
+               <number>1</number>
+              </property>
+              <property name="orientation">
+               <enum>Qt::Horizontal</enum>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QLabel" name="labImgQualityCurrent">
+              <property name="text">
+               <string notr="true">Current</string>
+              </property>
+              <property name="alignment">
+               <set>Qt::AlignCenter</set>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </widget>
+         </item>
+         <item>
+          <spacer name="verticalSpacer_5">
+           <property name="orientation">
+            <enum>Qt::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>298</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </widget>
        <widget class="QWidget" name="page_2">
         <layout class="QVBoxLayout" name="verticalLayout_3">
+         <property name="spacing">
+          <number>5</number>
+         </property>
          <property name="topMargin">
           <number>0</number>
          </property>
@@ -606,6 +428,9 @@
        </widget>
        <widget class="QWidget" name="page_4">
         <layout class="QVBoxLayout" name="verticalLayout_13">
+         <property name="spacing">
+          <number>5</number>
+         </property>
          <property name="topMargin">
           <number>0</number>
          </property>
@@ -842,63 +667,9 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <widget class="QPushButton" name="butRestoreOpt">
-       <property name="minimumSize">
-        <size>
-         <width>112</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Restore default settings</string>
-       </property>
-       <property name="text">
-        <string>Defaults</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>88</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="butSaveOpt">
-       <property name="minimumSize">
-        <size>
-         <width>112</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Save settings</string>
-       </property>
-       <property name="text">
-        <string>Save</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="butCancel">
-       <property name="minimumSize">
-        <size>
-         <width>112</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string>Discard changes</string>
-       </property>
-       <property name="text">
-        <string>Cancel</string>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::Cancel|QDialogButtonBox::RestoreDefaults|QDialogButtonBox::Save</set>
        </property>
       </widget>
      </item>
@@ -913,10 +684,6 @@
    <header>qkeysequencewidget.h</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>butSaveOpt</tabstop>
-  <tabstop>butCancel</tabstop>
- </tabstops>
  <resources/>
  <connections/>
 </ui>

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -345,7 +345,7 @@ void MainWindow::displatScreenToolTip()
     if (_conf->getEnableExtView())
     {
         toolTip += "\n\n";
-        toolTip += tr("Double click for open screenshot in external default image viewer");
+        toolTip += tr("Double click to open screenshot in external default image viewer");
     }
 
     _ui->scrLabel->setToolTip(toolTip);

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -542,7 +542,7 @@ void MainWindow::saveScreen()
     }
 
     QString fileName;
-    fileName = QFileDialog::getSaveFileName(this, tr("Save As..."),  filePath, fileFilters.join(";;"), &filterSelected, QFileDialog::DontUseNativeDialog);
+    fileName = QFileDialog::getSaveFileName(this, tr("Save As..."),  filePath, fileFilters.join(";;"), &filterSelected);
 
     QRegExp rx("\\(\\*\\.[a-z]{3,4}\\)");
     quint8 tmp = filterSelected.size() - rx.indexIn(filterSelected);

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -105,6 +105,8 @@ private Q_SLOTS:
     void delayBoxChange(int);
     void typeScreenShotChange(int type);
     void checkIncludeCursor(bool include);
+    void checkNoDecoration(bool noDecor);
+    void checkZommMouseArea(bool zoom);
     void updateUI();
     void trayClick(QSystemTrayIcon::ActivationReason reason);
 

--- a/src/core/ui/mainwindow.ui
+++ b/src/core/ui/mainwindow.ui
@@ -26,10 +26,10 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
-   <property name="layoutDirection">
-    <enum>Qt::RightToLeft</enum>
-   </property>
    <layout class="QVBoxLayout" name="verticalLayout">
+    <property name="spacing">
+     <number>5</number>
+    </property>
     <item>
      <widget class="QLabel" name="scrLabel">
       <property name="sizePolicy">
@@ -59,147 +59,137 @@
      </widget>
     </item>
     <item>
-     <widget class="QWidget" name="bottomBar" native="true">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <layout class="QHBoxLayout" name="horizontalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <spacer name="horizontalSpacer_2">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>13</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item>
-        <widget class="QComboBox" name="cbxTypeScr">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="toolTip">
-          <string>Type of screenshot</string>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Full screen</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Window</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Screen area</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Previous selection</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="labTypeScr">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="layoutDirection">
-          <enum>Qt::LeftToRight</enum>
-         </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <item>
+       <spacer name="horizontalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>5</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="labTypeScr">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Type:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cbxTypeScr">
+        <property name="enabled">
+         <bool>true</bool>
+        </property>
+        <property name="toolTip">
+         <string>Type of screenshot</string>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <item>
          <property name="text">
-          <string>Type: </string>
+          <string>Full screen</string>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QSpinBox" name="delayBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Delay in seconds before taking screenshot</string>
-         </property>
-         <property name="suffix">
-          <string> sec</string>
-         </property>
-         <property name="maximum">
-          <number>90</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="labDelay">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+        </item>
+        <item>
          <property name="text">
-          <string>Delay</string>
+          <string>Window</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+        </item>
+        <item>
+         <property name="text">
+          <string>Screen area</string>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>40</width>
-           <height>13</height>
-          </size>
+        </item>
+        <item>
+         <property name="text">
+          <string>Last selected area</string>
          </property>
-        </spacer>
-       </item>
-      </layout>
-     </widget>
+        </item>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_5">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>5</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QLabel" name="labDelay">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Delay:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QSpinBox" name="delayBox">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="toolTip">
+         <string>Delay in seconds before taking screenshot</string>
+        </property>
+        <property name="specialValueText">
+         <string>None</string>
+        </property>
+        <property name="suffix">
+         <string> sec</string>
+        </property>
+        <property name="maximum">
+         <number>90</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>5</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
     </item>
     <item>
      <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="spacing">
+       <number>10</number>
+      </property>
       <item>
        <spacer name="horizontalSpacer_3">
         <property name="orientation">
@@ -207,11 +197,25 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
-          <height>20</height>
+          <width>5</width>
+          <height>5</height>
          </size>
         </property>
        </spacer>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkZommMouseArea">
+        <property name="text">
+         <string>Zoom area around mouse</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QCheckBox" name="checkNoDecoration">
+        <property name="text">
+         <string>No window decoration</string>
+        </property>
+       </widget>
       </item>
       <item>
        <widget class="QCheckBox" name="checkIncludeCursor">
@@ -227,8 +231,8 @@
         </property>
         <property name="sizeHint" stdset="0">
          <size>
-          <width>40</width>
-          <height>20</height>
+          <width>5</width>
+          <height>5</height>
          </size>
         </property>
        </spacer>

--- a/src/modules/uploader/uploaderconfig.cpp
+++ b/src/modules/uploader/uploaderconfig.cpp
@@ -33,8 +33,7 @@ QStringList UploaderConfig::_labelsList = QStringList() << "Imgur";
 
 UploaderConfig::UploaderConfig()
 {
-    QString configFile = Config::getConfigDir() + QDir::separator() + "uploader.conf";
-    _settings = new QSettings(configFile, QSettings::IniFormat);
+    _settings = new QSettings ("screengrab", "uploader");
     _groupsList << "imgur.com" << "mediacru.sh";
 }
 


### PR DESCRIPTION
Fixes https://github.com/lxqt/screengrab/issues/48 and https://github.com/lxqt/screengrab/issues/49

(1) The screenshot settings of the main window are saved/restored (as in Spectacle). They are shown only when relevant to the chosen screenshot type.

(2) The item "Previous selecttion" is changed to "Last selected area" to be unambiguous. It means a screenshot inside the previously selected rectangle. Now, the selected rectangle is also saved on quitting and restored with the next session.

(3) Image format on saving is fixed.

(4) The special text of the spinbox ("None") is set in the ui file, not just when it has a zero value (that was a bad code).

(5) Also, the reading and writing of settings is simplified so that global config files could be used.