### PR TITLE
__DATE__ and __TIME__ macro are not very helpful for reproducible bui…

### DIFF
--- a/src/core/ui/about.cpp
+++ b/src/core/ui/about.cpp
@@ -31,15 +31,7 @@ AboutDialog::AboutDialog(QWidget *parent):
     _ui->setupUi(this);
     _ui->labAppName->setText(_ui->labAppName->text() + QString(" <b>") + qApp->applicationVersion() + QString("</b>"));
 
-    QString versionInfo;
-    versionInfo = tr("built on ");
-    versionInfo.append(__DATE__);
-    versionInfo.append(" ");
-    versionInfo.append(__TIME__);
-
     _ui->labQtVer->setText(tr("using Qt ") + qVersion());
-
-    _ui->labVersion->setText(versionInfo);
 
     QTabBar *tabs = new QTabBar;
 


### PR DESCRIPTION
…lds.

Beside of that the provided information is not relevant - nobody cares
when a binary is built. Qt version / components versions would make more
sense.