### PR TITLE
Several fixes, especially for the tray icon

### DIFF
--- a/src/core/ui/about.cpp
+++ b/src/core/ui/about.cpp
@@ -38,7 +38,6 @@ AboutDialog::AboutDialog(QWidget *parent):
     _ui->frame->layout()->addWidget(tabs);
     _ui->frame->layout()->addWidget(_ui->txtArea);
 
-    tabs->setFixedHeight(24);
     tabs->insertTab(0, tr("About"));
     tabs->insertTab(1, tr("Thanks"));
     tabs->insertTab(2, tr("Help us"));

--- a/src/core/ui/aboutwidget.ui
+++ b/src/core/ui/aboutwidget.ui
@@ -52,7 +52,7 @@
         <string/>
        </property>
        <property name="pixmap">
-        <pixmap resource="../../screengrab.qrc">:/res/img/logo.png</pixmap>
+        <pixmap resource="../../../screengrab.qrc">:/res/img/logo.png</pixmap>
        </property>
       </widget>
      </item>
@@ -160,8 +160,8 @@
   </layout>
  </widget>
  <resources>
-  <include location="../../screengrab.qrc"/>
-  <include location="../../screengrab.qrc"/>
+  <include location="../../../screengrab.qrc"/>
+  <include location="../../../screengrab.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -82,6 +82,7 @@ private:
     QMenu *_trayMenu;
     QShortcut *_hideWnd;
     bool _trayed;
+    QIcon appIcon;
 
 #ifdef SG_GLOBAL_SHORTCUTS
     QxtGlobalShortcut *_fullScreen;
@@ -95,6 +96,7 @@ private:
     void displatScreenToolTip();
     void createTray();
     void killTray();
+    void disableTrayMenuActions(bool disable);
     void updateShortcuts();
 
 private Q_SLOTS:


### PR DESCRIPTION
Fixes https://github.com/lxqt/screengrab/issues/63 and https://github.com/lxqt/screengrab/issues/61

(1) Several issues are fixed in the tray icon. Adding their long list to this comment wouldn't be helpful.

(2) The height of the About tab-bar shouldn't be enforced; otherwise, it'll interfer with the active widget style. Either don't do hard-coded styling or do it completely! There was no need to the latter here.

(3) The theme icon (if any) should always be preferred to the hard-coded icon (except for special cases that aren't related to this app).

(4) A wrong path is corrected in `aboutwidget.ui`.