### PR TITLE
No window screenshot with shaded windows

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -115,7 +115,7 @@ Config* Config::ptrInstance = 0;
 // constructor
 Config::Config()
 {
-    _settings = new QSettings ("screengrab", "screengrab");
+    _settings = new Settings("screengrab", "screengrab");
 
     _shortcuts = new ShortcutManager(_settings);
 

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -52,6 +52,20 @@ const bool DEF_ENABLE_EXT_VIEWER = true;
 const bool DEF_INCLUDE_CURSOR = false;
 const bool DEF_FIT_INSIDE = true;
 
+class Settings : public QSettings // prevents redundant writings
+{
+    Q_OBJECT
+public:
+    Settings(const QString &organization, const QString &application = QString(), QObject *parent = nullptr)
+        : QSettings (organization, application, parent) {}
+
+    void setValue(const QString &key, const QVariant &v) {
+        if (value(key) == v)
+            return;
+        QSettings::setValue(key, v);
+    }
+};
+
 // class worker with conf data
 class Config
 {
@@ -251,7 +265,7 @@ private:
      */
     void setValue(const QString& key, QVariant val);
 
-    QSettings *_settings;
+    Settings *_settings;
     QHash<QString, QVariant> _confData;
 
     ShortcutManager *_shortcuts;


### PR DESCRIPTION
Fixes https://github.com/lxqt/screengrab/issues/66

Take a fullscreen shot instead.

Also, no redundant writings to config file. This corrects a strange behavior of `QSettings`, due to which, config files are written to even when nothing is changed.