### PR TITLE
ui: set a name attribute to non-trivial value

### DIFF
--- a/src/core/ui/mainwindow.ui
+++ b/src/core/ui/mainwindow.ui
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
  <class>MainWindow</class>
- <widget class="QMainWindow" name="MainWindow">
+ <widget class="QMainWindow" name="ScreenGrab">
   <property name="geometry">
    <rect>
     <x>0</x>


### PR DESCRIPTION
The name attribute of top window is used as a *translation context*. It should be non-trivial to allow different translations