### PR TITLE
fixed misprint in Russian translation

### DIFF
--- a/translations/screengrab_ru.ts
+++ b/translations/screengrab_ru.ts
@@ -218,7 +218,7 @@
     <message>
         <location filename="../src/core/core.cpp" line="422"/>
         <source>Saved to </source>
-        <translation>Слхранено в </translation>
+        <translation>Сохранено в </translation>
     </message>
     <message>
         <location filename="../src/core/core.cpp" line="63"/>


### PR DESCRIPTION
I found misprint in Russian translation, it wasn't fixed for several versions, and I fixed it myself. Please, approve my PR.