### PR TITLE
Make KDE window system depencency optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -14,6 +14,7 @@ option(SG_DBUS_NOTIFY "Enable D-Bus notifications" ON)
 option(SG_EXT_EDIT "Enable ability to edit screenshots in external editor" ON)
 option(SG_EXT_UPLOADS "Enable upload screenshots to Imgur" ON)
 option(SG_GLOBALSHORTCUTS "Enable global shortcuts" OFF)
+option(SG_USE_SYSTEM_KF5 "Use KDE Frameworks 5 for active window detection" ON)
 option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" OFF)
 
 # Minimum Versions
@@ -25,7 +26,9 @@ find_package(Qt5LinguistTools  ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Network ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5Widgets ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt5X11Extras ${QT_MINIMUM_VERSION} REQUIRED)
-find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
+if (SG_USE_SYSTEM_KF5)
+    find_package(KF5WindowSystem ${KF5_MINIMUM_VERSION} REQUIRED)
+endif(SG_USE_SYSTEM_KF5)
 
 find_package(X11)
 if (X11_FOUND)
@@ -107,6 +110,7 @@ message(STATUS "Imgur upload support: " ${SG_EXT_UPLOADS})
 message(STATUS "Editing screenshots in external editor support: " ${SG_EXT_EDIT})
 message(STATUS "Enable D-Bus notifications: " ${SG_DBUS_NOTIFY})
 message(STATUS "Use system Qxt Library: " ${SG_USE_SYSTEM_QXT})
+message(STATUS "Use system KDE Frameworks 5" ${SG_USE_SYSTEM_KF5})
 message(STATUS "Update source translation translations/*.ts files: " ${UPDATE_TRANSLATIONS})
 
 # docs
@@ -224,6 +228,10 @@ if(SG_DBUS_NOTIFY)
     target_link_libraries(screengrab Qt5::DBus)
 endif()
 
+if(SG_USE_SYSTEM_KF5)
+    target_link_libraries(sceeengrab KF5::WindowSystem)
+endif()
+
 if (X11_XCB_FOUND)
     add_definitions( -DX11_XCB_FOUND="1")
     target_link_libraries(screengrab ${X11_XCB_LIBRARIES})
@@ -245,7 +253,7 @@ if (XCB_XFIXES_FOUND)
 endif()
 
 # Link with Network and X11Extras. See pull#86. TODO: Should be optional when upload module is needed.
-target_link_libraries(screengrab qkeysequencewidget Qt5::Widgets KF5::WindowSystem Qt5::X11Extras Qt5::Network ${X11_LIBRARIES})
+target_link_libraries(screengrab qkeysequencewidget Qt5::Widgets Qt5::X11Extras Qt5::Network ${X11_LIBRARIES})
 
 # installing
 install(TARGETS screengrab RUNTIME DESTINATION bin)

--- a/src/core/fixx11h.h
+++ b/src/core/fixx11h.h
@@ -1,0 +1,18 @@
+// This is a standard way (e.g., in KDE libs) of dealing
+// with X11 headers mess.
+
+#ifdef Bool
+#undef Bool
+#endif
+
+#ifdef CursorShape
+#undef CursorShape
+#endif
+
+#ifdef None
+#undef None
+#endif
+
+#ifdef Status
+#undef Status
+#endif

--- a/src/core/x11utils.h
+++ b/src/core/x11utils.h
@@ -24,7 +24,11 @@
 #include <QX11Info>
 
 #include <X11/Xlib-xcb.h>
+#ifdef SG_USE_SYSTEM_KF5
 #include <fixx11h.h>
+#else
+#include "fixx11h.h"
+#endif
 #include <xcb/xcb.h>
 
 namespace X11Utils {


### PR DESCRIPTION
Non-KDE code does not perform as many checks on the target window id.