### PR TITLE
Removed QDesktopWidget

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 
 # Minimum Versions
 set(KF5_MINIMUM_VERSION "5.36.0")
-set(QT_MINIMUM_VERSION "5.7.1")
+set(QT_MINIMUM_VERSION "5.10.0")
 set(QTXDG_MINIMUM_VERSION "3.4.0")
 
 find_package(Qt5LinguistTools  ${QT_MINIMUM_VERSION} REQUIRED)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -125,6 +125,8 @@ private:
     QString copyFileNameToCliipboard(QString file);
     void sendNotify(const StateNotifyMessage& message);
 
+    void getFullScreenPixmap(QScreen* screen);
+
     QPixmap *_pixelMap; // pixel map
     RegionSelect *_selector; // region grabber widget
     QRect _lastSelectedArea;

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -404,10 +404,11 @@
          <item>
           <widget class="QCheckBox" name="checkFitInside">
            <property name="toolTip">
-            <string>Fit to edges only inside selected screen area</string>
+            <string>If this is unchecked, the selected area
+might become larger to fit to outer edges</string>
            </property>
            <property name="text">
-            <string>Fit to edges inside selected area</string>
+            <string>Fit to edges inside selected area by right clicking</string>
            </property>
           </widget>
          </item>

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -23,7 +23,7 @@
 
 #include <QDir>
 #include <QFileDialog>
-#include <QDesktopWidget>
+#include <QScreen>
 #include <QHash>
 #include <QHashIterator>
 #include <QRegExp>
@@ -116,7 +116,8 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
     setWindowIcon(appIcon);
 
-    QRect geometry = QApplication::desktop()->availableGeometry(QApplication::desktop()->screenNumber());
+    auto screens = QGuiApplication::screens();
+    const QRect geometry = screens.isEmpty() ? QRect() : screens.at(0)->availableGeometry();
     move(geometry.width() / 2 - width() / 2, geometry.height() / 2 - height() / 2);
 
     _ui->scrLabel->installEventFilter(this);


### PR DESCRIPTION
Virtual screens are handled too.

Also:

 1. Added a better explanation, tooltip and screen label for fitting to edges.

 2. Previously, when a screenshot contained the window decoration but the window had an offscreen area, that area was black. Now, the screenshot only consists of the part that is inside the screen.

Closes https://github.com/lxqt/screengrab/issues/189  and closes https://github.com/lxqt/screengrab/issues/142