### PR TITLE
Fixed screen area and window modes with scale factors > 1

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -192,7 +192,7 @@ void Core::screenShot(bool first)
     sleep(400); // delay for hide "fade effect" bug in the KWin with compositing
     _firstScreen = first;
 
-    // Update date last crenshot, if it is  a first screen
+    // Update the last saving date, if this is the first screenshot
     if (_firstScreen)
         _conf->updateLastSaveDate();
 
@@ -301,6 +301,13 @@ void Core::getActiveWindow() // called only with window screenshots
     }
 
     QRect geometry = info.frameGeometry();
+
+    // WARNING: Until now, "KWindowInfo::frameGeometry" does not consider the screens's
+    // device pixel ratio. So, the frame geometry should be transformed.
+    qreal pixelRatio = screen->devicePixelRatio();
+    geometry.setTopLeft(QPointF(geometry.topLeft() / pixelRatio).toPoint());
+    geometry.setBottomRight(QPointF(geometry.bottomRight() / pixelRatio).toPoint());
+
     // The offscreen part of the window will appear as a black area in the screenshot.
     // Until a better method is found, the offscreen area is ignored here.
     QRect r = screen->virtualGeometry().intersected(geometry);
@@ -588,8 +595,8 @@ void Core::regionGrabbed(bool grabbed)
 
         int x = _selector->getSelectionStartPos().x();
         int y = _selector->getSelectionStartPos().y();
-        int w = _pixelMap->rect().width();
-        int h = _pixelMap->rect().height();
+        int w = _pixelMap->rect().width() / _pixelMap->devicePixelRatio();
+        int h = _pixelMap->rect().height() / _pixelMap->devicePixelRatio();
         _lastSelectedArea.setRect(x, y, w, h);
 
         checkAutoSave();

--- a/src/core/regionselect.h
+++ b/src/core/regionselect.h
@@ -60,7 +60,7 @@ Q_SIGNALS:
     void processDone(bool grabbed);
 
 private:
-    QRect _selectRect;
+    QRectF _selectRect;
     QSize _sizeDesktop;
 
     QPoint _selStartPoint;
@@ -81,6 +81,9 @@ private:
     void selectFit();
     void findFit();
     void fitBorder(const QRect &boundRect, enum Side side, int &border);
+
+    QRectF pixmapRect(const QRectF &widgetRect) const;
+    QRectF widgetRect(const QRectF &pixmapRect) const;
 
     Config *_conf;
 

--- a/src/core/x11utils.cpp
+++ b/src/core/x11utils.cpp
@@ -39,5 +39,9 @@ void X11Utils::compositePointer(int offsetX, int offsetY, QPixmap *snapshot)
                           QImage::Format_ARGB32_Premultiplied);
 
     QPainter painter(snapshot);
-    painter.drawImage(QPointF(cursor->x - cursor->xhot - offsetX, cursor->y - cursor ->yhot - offsetY), qcursorimg);
+
+    // NOTE: The device pixel ratio is not considered for the cursor automatically.
+    qreal pixelRatio = snapshot->devicePixelRatio();
+    qcursorimg.setDevicePixelRatio(pixelRatio);
+    painter.drawImage(QPointF((cursor->x - cursor->xhot) / pixelRatio - offsetX, (cursor->y - cursor ->yhot) / pixelRatio - offsetY), qcursorimg);
 }


### PR DESCRIPTION
Long story short, although the screen area widget covers the whole screen, the widget coordinates are different from the pixmap coordinates when scaling is enabled.

Also:

 1. In the window mode, "KWindowInfo::frameGeometry" doesn't consider the screen's device pixel ratio. So, it's taken into account by the patch.
 2. The device pixel ratio wasn't considered in grabbing the mouse cursor image either. That's corrected.
 3. Some old mistakes are corrected in the zooming code.

As far as I tested it, the patch worked fine with the scale factors 2 and, especially, 1.5 — the latter guarantees that it should work with all scale factors.

Closes https://github.com/lxqt/lxqt/issues/1814