### PR TITLE
Fix "using Qt [version]" message being too far down

### DIFF
--- a/src/core/ui/aboutwidget.ui
+++ b/src/core/ui/aboutwidget.ui
@@ -64,7 +64,7 @@
           <string notr="true">&lt;b&gt;ScreenGrab&lt;/b&gt;</string>
          </property>
          <property name="alignment">
-          <set>Qt::AlignBottom</set>
+          <set>Qt::AlignBottom|Qt::AlignHCenter</set>
          </property>
         </widget>
        </item>
@@ -74,7 +74,7 @@
           <string notr="true"/>
          </property>
          <property name="alignment">
-          <set>Qt::AlignTop</set>
+          <set>Qt::AlignHCenter|Qt::AlignTop</set>
          </property>
         </widget>
        </item>

--- a/src/core/ui/aboutwidget.ui
+++ b/src/core/ui/aboutwidget.ui
@@ -36,6 +36,53 @@
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="frameShadow">
+        <enum>QFrame::Plain</enum>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="pixmap">
+        <pixmap resource="../../../screengrab.qrc">:/res/img/logo.png</pixmap>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <item>
+        <widget class="QLabel" name="labAppName">
+         <property name="text">
+          <string notr="true">&lt;b&gt;ScreenGrab&lt;/b&gt;</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignBottom</set>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="labQtVer">
+         <property name="text">
+          <string notr="true"/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+    </layout>
+   </item>
+   <item>
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -44,61 +91,6 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QVBoxLayout" name="_2">
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout">
-        <item>
-         <widget class="QLabel" name="label">
-          <property name="sizePolicy">
-           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-            <horstretch>0</horstretch>
-            <verstretch>0</verstretch>
-           </sizepolicy>
-          </property>
-          <property name="frameShadow">
-           <enum>QFrame::Plain</enum>
-          </property>
-          <property name="text">
-           <string/>
-          </property>
-          <property name="pixmap">
-           <pixmap resource="../../../screengrab.qrc">:/res/img/logo.png</pixmap>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <layout class="QVBoxLayout" name="verticalLayout_2">
-          <item>
-           <widget class="QLabel" name="labAppName">
-            <property name="text">
-             <string notr="true">&lt;b&gt;ScreenGrab&lt;/b&gt;</string>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignBottom|Qt::AlignHCenter</set>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QLabel" name="labQtVer">
-            <property name="font">
-             <font>
-              <family>Sans Serif</family>
-              <pointsize>11</pointsize>
-              <weight>50</weight>
-              <bold>false</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string notr="true"/>
-            </property>
-            <property name="alignment">
-             <set>Qt::AlignHCenter|Qt::AlignTop</set>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </item>
-       </layout>
-      </item>
       <item>
        <widget class="QTextBrowser" name="txtArea">
         <property name="openExternalLinks">
@@ -160,7 +152,6 @@
  <resources>
   <include location="../../../screengrab.qrc"/>
   <include location="../../../screengrab.qrc"/>
-  <include location="../../../../../screengrab.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/core/ui/aboutwidget.ui
+++ b/src/core/ui/aboutwidget.ui
@@ -36,63 +36,6 @@
     <enum>QLayout::SetDefaultConstraint</enum>
    </property>
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="label">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="frameShadow">
-        <enum>QFrame::Plain</enum>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="pixmap">
-        <pixmap resource="../../../screengrab.qrc">:/res/img/logo.png</pixmap>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <layout class="QVBoxLayout" name="verticalLayout_2">
-       <item>
-        <widget class="QLabel" name="labAppName">
-         <property name="text">
-          <string notr="true">&lt;b&gt;ScreenGrab&lt;/b&gt;</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="labVersion">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="labQtVer">
-         <property name="text">
-          <string notr="true"/>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
     <widget class="QFrame" name="frame">
      <property name="frameShape">
       <enum>QFrame::StyledPanel</enum>
@@ -101,6 +44,61 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QVBoxLayout" name="_2">
+      <item>
+       <layout class="QHBoxLayout" name="horizontalLayout">
+        <item>
+         <widget class="QLabel" name="label">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>0</horstretch>
+            <verstretch>0</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="frameShadow">
+           <enum>QFrame::Plain</enum>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+          <property name="pixmap">
+           <pixmap resource="../../../screengrab.qrc">:/res/img/logo.png</pixmap>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <layout class="QVBoxLayout" name="verticalLayout_2">
+          <item>
+           <widget class="QLabel" name="labAppName">
+            <property name="text">
+             <string notr="true">&lt;b&gt;ScreenGrab&lt;/b&gt;</string>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignBottom|Qt::AlignHCenter</set>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QLabel" name="labQtVer">
+            <property name="font">
+             <font>
+              <family>Sans Serif</family>
+              <pointsize>11</pointsize>
+              <weight>50</weight>
+              <bold>false</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="alignment">
+             <set>Qt::AlignHCenter|Qt::AlignTop</set>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </item>
+       </layout>
+      </item>
       <item>
        <widget class="QTextBrowser" name="txtArea">
         <property name="openExternalLinks">
@@ -162,6 +160,7 @@
  <resources>
   <include location="../../../screengrab.qrc"/>
   <include location="../../../screengrab.qrc"/>
+  <include location="../../../../../screengrab.qrc"/>
  </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Before:
![screenshot-80bcbdc2](https://user-images.githubusercontent.com/77978836/125857696-a499a423-ccde-4f86-9b42-ac10a0c6678f.jpg)

After:
![screenshot-459cee6a](https://user-images.githubusercontent.com/77978836/125857742-4451a9f7-a7be-4aae-a981-c25ef067bbe3.jpg)
