### PR TITLE
Removed global shortcuts

### DIFF
--- a/src/common/qkeysequencewidget/src/qkeysequencewidget.cpp
+++ b/src/common/qkeysequencewidget/src/qkeysequencewidget.cpp
@@ -165,6 +165,14 @@ void QKeySequenceWidget::clearKeySequence()
 }
 
 /*!
+    Cancels recosring.
+ */
+void QKeySequenceWidget::cancelRecording()
+{
+    d_ptr->cancelRecording();
+}
+
+/*!
  * Start process capturing key sequence.
  * This slot is designed for software process capturing key sequence.
  */

--- a/src/common/qkeysequencewidget/src/qkeysequencewidget.h
+++ b/src/common/qkeysequencewidget/src/qkeysequencewidget.h
@@ -94,6 +94,7 @@ public:
     QKeySequence keySequence() const;
     QString noneText() const;
     QIcon clearButtonIcon() const;
+    void cancelRecording();
 
     /*!
       \brief Modes of sohow ClearButton

--- a/src/core/ui/configwidget.h
+++ b/src/core/ui/configwidget.h
@@ -50,7 +50,6 @@ private:
     QStringList _moduleWidgetNames;
 
 private slots:
-    void collapsTreeKeys(QModelIndex index);
     void doubleclickTreeKeys(QModelIndex index);
     void toggleCheckShowTray(bool checked);
     void currentItemChanged(const QModelIndex c ,const QModelIndex p);

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -583,61 +583,33 @@ might become larger to fit to outer edges</string>
            </column>
            <item>
             <property name="text">
-             <string>Global shortcuts</string>
+             <string>New screen</string>
             </property>
-            <property name="text">
-             <string/>
-            </property>
-            <item>
-             <property name="text">
-              <string>Full screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Active window</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Area select</string>
-             </property>
-            </item>
            </item>
            <item>
             <property name="text">
-             <string>Local shortcuts</string>
+             <string>Save screen</string>
             </property>
-            <item>
-             <property name="text">
-              <string>New screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Save screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Copy screen</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Options</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Help</string>
-             </property>
-            </item>
-            <item>
-             <property name="text">
-              <string>Quit</string>
-             </property>
-            </item>
+           </item>
+           <item>
+            <property name="text">
+             <string>Copy screen</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Options</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Help</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Quit</string>
+            </property>
            </item>
           </widget>
          </item>


### PR DESCRIPTION
… Without removing their main code.

Global shortcuts weren't used anywhere. They also shouldn't be used because a screenshot utility is an ordinary app.

Also, a bug is fixed in the shortcut editor.

Closes https://github.com/lxqt/screengrab/issues/291