### PR TITLE
Fixed several problems in calling external editors or default app

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -25,8 +25,12 @@
 #include <QFile>
 #include <QDir>
 #include <QUuid>
+#include <QMimeDatabase>
 
 #include <QDebug>
+
+#include <XdgMimeApps>
+#include <qt5xdg/XdgDesktopFile>
 
 #include <KF5/KWindowSystem/KWindowSystem>
 #include <xcb/xfixes.h>
@@ -97,6 +101,7 @@ Core* Core::instance()
 
 Core::~Core()
 {
+    killTempFile();
     delete _pixelMap;
     _conf->killInstance();
 }
@@ -189,6 +194,8 @@ void Core::getFullScreenPixmap(QScreen* screen)
 // get screenshot
 void Core::screenShot(bool first)
 {
+    killTempFile(); // remove the old temp fle if any
+
     sleep(400); // delay for hide "fade effect" bug in the KWin with compositing
     _firstScreen = first;
 
@@ -393,20 +400,24 @@ void Core::updatePixmap()
 
 QString Core::getTempFilename(const QString& format)
 {
-    _tempFilename = QUuid::createUuid().toString();
-    int size = _tempFilename.size() - 2;
-    _tempFilename = _tempFilename.mid(1, size).left(8);
-    _tempFilename = QDir::tempPath() + QDir::separator() + QStringLiteral("screenshot-") + _tempFilename + QStringLiteral(".") + format;
+    if (_tempFilename.isEmpty())
+    {
+        killTempFile(); // remove the old temp file if any
+        _tempFilename = QUuid::createUuid().toString();
+        int size = _tempFilename.size() - 2;
+        _tempFilename = _tempFilename.mid(1, size).left(8);
+        _tempFilename = QDir::tempPath() + QDir::separator()
+                        + QStringLiteral("screenshot-") + _tempFilename
+                        + QStringLiteral(".") + format;
+    }
     return _tempFilename;
 }
 
 void Core::killTempFile()
 {
     if (QFile::exists(_tempFilename))
-    {
         QFile::remove(_tempFilename);
-        _tempFilename.clear();
-    }
+    _tempFilename.clear();
 }
 
 bool Core::writeScreen(QString& fileName, QString& format, bool tmpScreen)
@@ -500,23 +511,21 @@ void Core::openInExtViewer()
         QString tempFileName = getTempFilename(format);
         writeScreen(tempFileName, format, true);
 
-        QString exec;
-        exec = QLatin1String("xdg-open");
-        QStringList args;
-        args << tempFileName;
+        QMimeDatabase db;
+        XdgMimeApps mimeAppsDb;
+        QMimeType mt = db.mimeTypeForFile(tempFileName);
+        auto app = mimeAppsDb.defaultApp(mt.name());
+        if (app != nullptr)
+        {
+            QString exec;
+            exec = app->expandExecString().first();
+            delete app;
+            QStringList args;
+            args << tempFileName;
 
-        QProcess *execProcess = new QProcess(this);
-
-        void (QProcess:: *signal)(int, QProcess::ExitStatus) = &QProcess::finished;
-        connect(execProcess, signal, this, &Core::closeExtViewer);
-        execProcess->start(exec, args);
+            QProcess::startDetached(exec, args);
+        }
     }
-}
-
-void Core::closeExtViewer(int, QProcess::ExitStatus)
-{
-    sender()->deleteLater();
-    killTempFile();
 }
 
 ModuleManager* Core::modules()

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -194,7 +194,7 @@ void Core::getFullScreenPixmap(QScreen* screen)
 // get screenshot
 void Core::screenShot(bool first)
 {
-    killTempFile(); // remove the old temp fle if any
+    killTempFile(); // remove the old temp file if any
 
     sleep(400); // delay for hide "fade effect" bug in the KWin with compositing
     _firstScreen = first;
@@ -402,7 +402,6 @@ QString Core::getTempFilename(const QString& format)
 {
     if (_tempFilename.isEmpty())
     {
-        killTempFile(); // remove the old temp file if any
         _tempFilename = QUuid::createUuid().toString();
         int size = _tempFilename.size() - 2;
         _tempFilename = _tempFilename.mid(1, size).left(8);

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -144,7 +144,6 @@ private:
 
 private Q_SLOTS:
     void regionGrabbed(bool grabbed);
-    void closeExtViewer(int exitCode, QProcess::ExitStatus exitStatus);
 
 };
 

--- a/src/core/modulemanager.cpp
+++ b/src/core/modulemanager.cpp
@@ -37,6 +37,16 @@ void ModuleManager::initModules()
 #endif
 }
 
+ModuleManager::~ModuleManager()
+{
+    if (!_modules->isEmpty())
+    {
+        qDeleteAll(_modules->values());
+        _modules->clear();
+    }
+    delete _modules;
+}
+
 AbstractModule* ModuleManager::getModule(const QByteArray& name)
 {
     if (_modules->contains(name))

--- a/src/core/modulemanager.h
+++ b/src/core/modulemanager.h
@@ -36,6 +36,7 @@ class ModuleManager
 {
 public:
     ModuleManager();
+    ~ModuleManager();
     void initModules();
     AbstractModule* getModule(const QByteArray& name);
     AbstractModule* getModule(const quint8 numid);

--- a/src/modules/extedit/extedit.h
+++ b/src/modules/extedit/extedit.h
@@ -37,16 +37,12 @@ public Q_SLOTS:
     void runExternalEditor();
 
 private Q_SLOTS:
-    void closedExternalEditor(int exitCode, QProcess::ExitStatus exitStatus);
     void editedFileChanged(const QString & path);
 
 private:
     void createAppList();
 
-    QList<XdgDesktopFile*> _appList;
     QList<XdgAction*> _actionList;
-    QString _editFilename;
-    bool _fileIsChanged;
     QFileSystemWatcher *_watcherEditedFile;
 };
 


### PR DESCRIPTION
The following problems are fixed. Previously,

 1. If an image editor/viewer had a single instance and was already running before Screengrab was launched, Screengrab couldn't open a screenshot in it.
 2. Double clicking inside the main window might give a nonexistent image to the default viewer.
 3. There were memory leaks.
 4. Screengrab might leave behind temporary images (in `/tmp/`) if multiple external apps/editors were called in parallel or Screengrab exited before the app(s)/editor(s).
 5. If an image editor was called, the edited screenshot would appear in Screengrab only after the editor was closed — saving by the editor wouldn't be enough.
 6. If an image editor was called and a new screenshot was taken during editing, the old edited screenshot would replace the new one inside the main window after editing was finished and the editor was closed.

 Now,
 1. The editor/viewer is always started as a detached process, so that single-instance editors/viewers can be called without problem.
 2. Double clicking inside the main window works as expected.
 3. The d-tor of `ModuleManager` performs a correct cleanup, preventing a memory leak.
 4. The edited screenshot appears in Screengrab as soon as it's saved by the editor.
 5. The old (edited or non-edited) screenshot will be forgotten if not saved explicitly as soon as a new screenshot is taken.
 6. No temporary image is left behind in `/tmp/` when the app exits — if the user wants permanent images, he/she should save them explicitly.

Fixes https://github.com/lxqt/screengrab/issues/297 and fixes https://github.com/lxqt/screengrab/issues/296 and fixes https://github.com/lxqt/screengrab/issues/294

NOTE: Sadly, Screengrab doesn't have a clean code. This patch does some cleanup but only as far as its goals are concerned.