### PR TITLE
Removed shared libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,10 +66,6 @@ message(STATUS "Install prefix: " ${CMAKE_INSTALL_PREFIX})
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wnon-virtual-dtor -Woverloaded-virtual -Wall -Wextra")
 
-set(SG_LIBDIR "${CMAKE_INSTALL_LIBDIR}/screengrab")
-set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/${SG_LIBDIR}")
-message(STATUS "Library path: ${CMAKE_INSTALL_RPATH}")
-
 # Although the names, LXQtTranslateTs and LXQtTranslateDesktop, they don't
 #   bring any dependency on lxqt.
 include(LXQtTranslateTs)

--- a/README.md
+++ b/README.md
@@ -50,7 +50,6 @@ config files were stored in ~/.screengrab (Set this parameter to "OFF" to store 
  * **-DSG_GLOBALSHORTCUTS** - Enable global shortcuts for main actions to create screenshots. Default setting: ON.
  * **-DSG_USE_SYSTEM_QXT** - Use system version Qxt Library for global shortcuts. Default setting: OFF.
  * **-DSG_DOCDIR** - Name for the directory of user's documentation. Default setting:  "screengrab".
- * **-DQKSW_SHARED** - Enable shared linking with qkeysequencewidget library (in src/common/qksysekwesewidget).
 Dfault setting: OFF.
  * **-DDEV_VERSION** - Set a dev-version here, maybe git describe $foo. Default not set.
 

--- a/src/common/qkeysequencewidget/CMakeLists.txt
+++ b/src/common/qkeysequencewidget/CMakeLists.txt
@@ -3,8 +3,6 @@ include_directories(${Qt5Widgets_INCLUDE_DIRS})
 
 add_definitions(${Qt5Widgets_DEFINITIONS})
 
-OPTION (QKSW_SHARED "Use QKeysequenseWidget as shared library" OFF)
-
 set (QKSW_SRC
   src/qkeysequencewidget.cpp)
 
@@ -17,13 +15,6 @@ set (QKSW_QRC
 
 qt5_add_resources(QKSW_QRC ${QKSW_QRC})
 
-if(QKSW_SHARED)
-    add_definitions(-DIS_SHARED="true")
-	add_library(qkeysequencewidget SHARED ${QKSW_SRC} ${QKSW_QRC})
-	set_property(TARGET qkeysequencewidget PROPERTY SOVERSION 1.0.0)
-	INSTALL (TARGETS qkeysequencewidget DESTINATION ${SG_LIBDIR})
-else(QKSW_SHARED)
-	add_library(qkeysequencewidget STATIC ${QKSW_SRC} ${QKSW_QRC})
-endif(QKSW_SHARED)
+add_library(qkeysequencewidget STATIC ${QKSW_SRC} ${QKSW_QRC})
 
 target_link_libraries(qkeysequencewidget Qt5::Widgets)

--- a/src/common/qkeysequencewidget/src/qkeysequencewidget.h
+++ b/src/common/qkeysequencewidget/src/qkeysequencewidget.h
@@ -34,12 +34,6 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <QWidget>
 #include <QIcon>
 
-#if defined IS_SHARED
-#define QKSW_EXPORT Q_DECL_EXPORT
-#else
-#define QKSW_EXPORT Q_DECL_IMPORT
-#endif
-
 class QKeySequenceWidgetPrivate;
 
 /*!
@@ -68,7 +62,7 @@ class QKeySequenceWidgetPrivate;
     connect(keyWidget, SIGNAL(keySequenceChanged(QKeySequence)), this, SLOT(slotKeySequenceChanged(QKeySequence)));
   \endcode
 */
-class QKSW_EXPORT QKeySequenceWidget : public QWidget
+class QKeySequenceWidget : public QWidget
 {
     Q_OBJECT
     Q_DECLARE_PRIVATE(QKeySequenceWidget);

--- a/src/modules/extedit/CMakeLists.txt
+++ b/src/modules/extedit/CMakeLists.txt
@@ -24,12 +24,10 @@ qt5_translation_loader(extedit_QM_LOADER
 )
 
 add_library(extedit
-    SHARED
+    STATIC
         ${extedit_SRC}
         ${extedit_QMS}
         ${extedit_QM_LOADER}
 )
-set_property (TARGET extedit PROPERTY SOVERSION 1.0.0)
-install(TARGETS extedit DESTINATION ${SG_LIBDIR})
 
 target_link_libraries(extedit Qt5::Widgets Qt5::X11Extras Qt5Xdg)


### PR DESCRIPTION
`qkeysequencewidget` was static by default. But `extedit` was shared, while depending on the core code. It made the compilation fail with `--no-undefined`.

Fixes https://github.com/lxqt/screengrab/issues/310