### PR TITLE
Port away from obsolete QLabel method

### DIFF
--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -142,7 +142,8 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 
     scaleSize.scale(_ui->scrLabel->contentsRect().size(), Qt::KeepAspectRatio);
 
-    if (!_ui->scrLabel->pixmap() || scaleSize != _ui->scrLabel->pixmap()->size())
+    const QPixmap pixmap = _ui->scrLabel->pixmap(Qt::ReturnByValue);
+    if (pixmap.isNull() || scaleSize != pixmap.size())
         updatePixmap(Core::instance()->getPixmap());
 }
 


### PR DESCRIPTION
Qt provided a version of pixmap() which returned the pixmap by-pointer.
That version is now obsolete.
