### PR TITLE
PT_BR grammar correction

### DIFF
--- a/translations/screengrab_pt_BR.ts
+++ b/translations/screengrab_pt_BR.ts
@@ -71,7 +71,7 @@
     <message>
         <location filename="../src/core/ui/about.cpp" line="127"/>
         <source>Report bugs and issues</source>
-        <translation>Imformar bugs e problemas</translation>
+        <translation>Informar bugs e problemas</translation>
     </message>
     <message>
         <location filename="../src/core/ui/about.cpp" line="130"/>


### PR DESCRIPTION
PT_BR grammar correction
IMFORMAR => INFORMAR

https://en.wikipedia.org/wiki/Portuguese_orthography#cite_ref-29 https://dictionary.cambridge.org/pt/dicionario/portugues-ingles/informar