### PR TITLE
Call setDesktopFileName(...) to set proper app-id on wayland

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -29,6 +29,7 @@ int main(int argc, char *argv[])
     scr.setOrganizationName(QStringLiteral("lxqt"));
     scr.setOrganizationDomain(QStringLiteral("https://lxqt.org"));
     scr.setApplicationName(QStringLiteral("screengrab"));
+    scr.setDesktopFileName(QStringLiteral("screengrab"));
     Core *ScreenGrab = Core::instance();
     ScreenGrab->modules()->initModules();
     ScreenGrab->processCmdLineOpts(scr.arguments());


### PR DESCRIPTION
This PR fixes the app-id of this application.

Currently, the application name (`screengrab`) and organisation domain (`https://lxqt.org`) are set. Since `desktopFileName` is not set, Qt in a misguided attempt inverts the org-domain (giving us `org.https://lxqt`) and then appends the application name,  to give us an app-id, resulting in this beautiful expression: `org.https://lxqt.screengrab`

This fix for this is simple: just call `QApplication::setDesktopFileName(...)`.