### PR TITLE
Corrected the organization domain

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -27,7 +27,7 @@ int main(int argc, char *argv[])
     SingleApp scr(argc, argv, QStringLiteral(VERSION));
     scr.setApplicationVersion(QStringLiteral(VERSION));
     scr.setOrganizationName(QStringLiteral("lxqt"));
-    scr.setOrganizationDomain(QStringLiteral("https://lxqt.org"));
+    scr.setOrganizationDomain(QStringLiteral("lxqt-project.org"));
     scr.setApplicationName(QStringLiteral("screengrab"));
     Core *ScreenGrab = Core::instance();
     ScreenGrab->modules()->initModules();


### PR DESCRIPTION
Adding an organization domain wasn't needed, but if it is added, it should be correct. In particular, `https://` shouldn't be included — it makes a Wayland icon name impossible.