### PR TITLE
Don't allocate useless resources in single instance mode

### DIFF
--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -31,10 +31,6 @@ int main(int argc, char *argv[])
     scr.setApplicationName(QStringLiteral("screengrab"));
     scr.setDesktopFileName(QStringLiteral("screengrab"));
     Core *ScreenGrab = Core::instance();
-    ScreenGrab->modules()->initModules();
-    ScreenGrab->processCmdLineOpts(scr.arguments());
-
-    QObject::connect(&scr, &SingleApp::messageReceived, ScreenGrab, &Core::initWindow);
 
     if (!ScreenGrab->config()->getAllowMultipleInstance() && scr.isRunning())
     {
@@ -42,6 +38,10 @@ int main(int argc, char *argv[])
         scr.sendMessage(QStringLiteral("screengrab --type=") + type);
         return 0;
     }
+
+    ScreenGrab->modules()->initModules();
+    ScreenGrab->processCmdLineOpts(scr.arguments());
+    QObject::connect(&scr, &SingleApp::messageReceived, ScreenGrab, &Core::initWindow);
 
     return scr.exec();
 }


### PR DESCRIPTION
In the single instance mode, the code initialized a window with its modules and made a useless signal-slot connection if screengrab was called while another instance was already running. Of course, they were all deleted instantly.

The patch does the initialization only for the main instance.