### PR TITLE
Fixed handling of shared memory

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -559,10 +559,10 @@ void Core::processCmdLineOpts(const QStringList& arguments)
 
     // Check commandline parameters and set screenshot type
     for (int i=0; i < _screenTypeOpts.count(); ++i)
+    {
         if (_cmdLine.isSet(_screenTypeOpts.at(i)))
             _conf->setDefScreenshotType(i);
-
-    initWindow();
+    }
 }
 
 bool Core::runAsMinimized()

--- a/src/core/singleapp.h
+++ b/src/core/singleapp.h
@@ -25,26 +25,27 @@
 
 class SingleApp : public QApplication
 {
-        Q_OBJECT
+    Q_OBJECT
 public:
-        SingleApp(int &argc, char *argv[], const QString &keyString);
+    SingleApp(int &argc, char *argv[], const QString &keyString);
+    void init();
 
-        bool isRunning();
-        bool sendMessage(const QString &message);
+    bool isRunning();
+    bool sendMessage(const QString &message);
 
 public Q_SLOTS:
-        void receiveMessage();
+    void receiveMessage();
 
 Q_SIGNALS:
-        void messageReceived(const QString& message);
+    void messageReceived(const QString& message);
 
 private:
-        bool runned;
-        QString uniqueKey;
-        QSharedMemory sharedMemory;
-        QLocalServer *localServer;
+    bool running;
+    QString uniqueKey;
+    QSharedMemory sharedMemory;
+    QLocalServer *localServer;
 
-        static const int timeout = 1000;
+    static const int timeout = 1000;
 };
 
 #endif // SINGLEAPP_H


### PR DESCRIPTION
Previously, if the help or version option was given, the shared memory wasn't cleared and so, the app couldn't be started again in the single-instance mode.

Fixes https://github.com/lxqt/screengrab/issues/184