### PR TITLE
Fixed FTBFS due to `cmake_minimum_required`

### DIFF
--- a/cmake/LXQtTranslateTs.cmake
+++ b/cmake/LXQtTranslateTs.cmake
@@ -53,7 +53,7 @@
 
 
 # CMake v2.8.3 needed to use the CMakeParseArguments module
-cmake_minimum_required(VERSION 2.8.3 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.18.0 FATAL_ERROR)
 
 
 function(lxqt_translate_ts qmFiles)


### PR DESCRIPTION
It's in `cmake/LXQtTranslateTs.cmake` and resulted in

```
CMake Error at cmake/LXQtTranslateTs.cmake:56 (cmake_minimum_required):
  Compatibility with CMake < 3.5 has been removed from CMake
```

NOTE: This should be merged before the release!