### PR TITLE
Wayland screenshot with "wlr screencopy protocol"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,12 +16,15 @@ option(UPDATE_TRANSLATIONS "Update source translation translations/*.ts files" O
 # Minimum Versions
 set(KF6_MINIMUM_VERSION "6.0.0")
 set(QT_MINIMUM_VERSION "6.6.0")
+set(SHELLQT_MINIMUM_VERSION "6.0.0")
 set(QTXDG_MINIMUM_VERSION "4.2.0")
 set(LXQTBT_MINIMUM_VERSION "2.2.0")
 
 find_package(Qt6Network ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6Widgets ${QT_MINIMUM_VERSION} REQUIRED)
+find_package(Qt6WaylandClient ${QT_MINIMUM_VERSION} REQUIRED)
 find_package(Qt6LinguistTools  ${QT_MINIMUM_VERSION} REQUIRED)
+find_package(LayerShellQt ${SHELLQT_MINIMUM_VERSION} REQUIRED)
 find_package(KF6WindowSystem ${KF6_MINIMUM_VERSION} REQUIRED)
 find_package(lxqt2-build-tools ${LXQTBT_MINIMUM_VERSION} REQUIRED)
 
@@ -82,7 +85,6 @@ endif()
 
 message(STATUS "Editing screenshots in external editor support: " ${SG_EXT_EDIT})
 message(STATUS "Enable D-Bus notifications: " ${SG_DBUS_NOTIFY})
-message(STATUS "Use system Qxt Library: " ${SG_USE_SYSTEM_QXT})
 message(STATUS "Update source translation translations/*.ts files: " ${UPDATE_TRANSLATIONS})
 
 # docs
@@ -113,6 +115,8 @@ set(SCREENGRAB_SRC
     src/core/ui/configwidget.cpp
     src/core/ui/about.cpp
     src/core/ui/mainwindow.cpp
+    src/core/wayland/ScreenCopy.cpp
+    src/core/wayland/ScreenShot.cpp
 )
 
 if(SG_DBUS_NOTIFY)
@@ -204,7 +208,12 @@ if (XCB_XFIXES_FOUND)
 endif()
 
 # Link with Network. See pull#86. TODO: Should be optional when upload module is needed.
-target_link_libraries(screengrab qkeysequencewidget Qt6::Widgets KF6::WindowSystem Qt6::Network ${X11_LIBRARIES})
+target_link_libraries(screengrab qkeysequencewidget Qt6::Widgets KF6::WindowSystem Qt6::Network ${X11_LIBRARIES}
+LayerShellQtInterface Qt6::GuiPrivate Qt6::WaylandClient Qt6::WaylandClientPrivate Qt6::WaylandGlobalPrivate)
+
+qt6_generate_wayland_protocol_client_sources(screengrab FILES
+    ${CMAKE_CURRENT_SOURCE_DIR}/src/core/wayland/wlr-screencopy-unstable-v1.xml
+)
 
 # installing
 install(TARGETS screengrab RUNTIME DESTINATION bin)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ it is independent from any desktop environment.
  * Qt6 >= 6.6
  * CMake >= 3.1.0 (only for building ScreenGrab from sources)
  * GCC > 4.5
- * KF6WindowSystem
+ * KF6WindowSystem (for X11 support)
+ * qt6-wayland >= 6.6 (for Wayland support)
+ * layershell-qt >= 6 (for Wayland support)
  * [lxqt-build-tools](https://github.com/lxqt/lxqt-build-tools)
  * [libqtxdg](https://github.com/lxqt/libqtxdg/)(if compiled with the ability to edit screenshots in external apps, which is the case by default)
 
@@ -42,13 +44,9 @@ To build ScreenGrab from sources, use these commands:
 You can use some or all of these parameters to customise your build.
 
  * **-DCMAKE_INSTALL_PREFIX** - Install prefix for Linux distro. Default setting: "/usr".
- * **-DSG_XDG_CONFIG_SUPPORT** - Place config files into XDGC_CONFIG_HOME directory
 (usually - ~/.config/${app_name) ). Default setting: ON. In previous versions the
 config files were stored in ~/.screengrab (Set this parameter to "OFF" to store the config files here).
- * **-DSG_EXT_UPLOADS** - Enable uploading screenshots to image hosting services. Default setting: ON.
  * **-DSG_DBUS_NOTIFY** - Enable D-Bus notifications.
- * **-DSG_GLOBALSHORTCUTS** - Enable global shortcuts for main actions to create screenshots. Default setting: ON.
- * **-DSG_USE_SYSTEM_QXT** - Use system version Qxt Library for global shortcuts. Default setting: OFF.
  * **-DSG_DOCDIR** - Name for the directory of user's documentation. Default setting:  "screengrab".
 Dfault setting: OFF.
  * **-DDEV_VERSION** - Set a dev-version here, maybe git describe $foo. Default not set.

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -319,6 +319,7 @@ void Core::showWaylandScreenshot(const QPixmap& pixmap)
     if (!pixmap.isNull())
     {
         *_pixelMap = pixmap;
+        checkAutoSave(_firstScreen);
         _wnd->updatePixmap(_pixelMap);
         _wnd->restoreFromShot();
     }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -47,6 +47,8 @@
 #include "dbusnotifier.h"
 #endif
 
+#include "wayland/ScreenShot.h"
+
 Core* Core::corePtr = nullptr;
 
 Core::Core()
@@ -80,7 +82,8 @@ Core::Core()
     QCommandLineOption optRunMinimized(QStringList() << QStringLiteral("m") << QStringLiteral("minimized"), tr("Run the application with a hidden main window"));
     _cmdLine.addOption(optRunMinimized);
 
-    sleep(250);
+    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+        sleep(250);
 
     _wnd = nullptr;
 }
@@ -118,9 +121,8 @@ void Core::initWindow(const QString& ipcMessage)
 
         screenShot(true); // first screenshot
 
-        _wnd->resize(_conf->getRestoredWndSize());
-
-        if (_wnd) {
+        if (QGuiApplication::platformName() != QStringLiteral("wayland")) {
+            _wnd->resize(_conf->getRestoredWndSize());
             if (runAsMinimized())
             {
                 if (_wnd->isTrayed())
@@ -198,12 +200,19 @@ void Core::screenShot(bool first)
 {
     killTempFile(); // remove the old temp file if any
 
-    sleep(400); // delay for hide "fade effect" bug in the KWin with compositing
+    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+        sleep(400); // delay for hide "fade effect" bug in the KWin with compositing
     _firstScreen = first;
 
     // Update the last saving date, if this is the first screenshot
     if (_firstScreen)
         _conf->updateLastSaveDate();
+
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        waylandScreenShot();
+        return;
+    }
 
     switch(_conf->getDefScreenshotType())
     {
@@ -247,6 +256,85 @@ void Core::screenShot(bool first)
 
     _wnd->updatePixmap(_pixelMap);
     _wnd->restoreFromShot();
+}
+
+// Should be called only on Wayland.
+void Core::waylandScreenShot()
+{
+    if (_selector != nullptr)
+        return; // an area screenshot is in progress
+
+    switch(_conf->getDefScreenshotType())
+    {
+    case Core::Area:
+        _selector = new RegionSelect(_conf, _wnd->selectedScreen());
+        [[fallthrough]];
+    case Core::PreviousSelection:
+    {
+        if (_selector == nullptr)
+            _selector = new RegionSelect(_conf, _lastSelectedArea, _wnd->selectedScreen());
+        connect(_selector, &RegionSelect::processDone, this, [this](bool grabbed) {
+            if (!grabbed)
+            {
+                _wnd->restoreFromShot();
+                _selector->deleteLater();
+                _selector = nullptr;
+                return;
+            }
+            auto ws = new LXQt::Wayland::ScreenShot(false,
+                                                    _wnd->selectedScreen(),
+                                                    _selector->getSelectionRect(),
+                                                    this);
+            _selector->hide();
+            connect(ws, &LXQt::Wayland::ScreenShot::screenShotReady, this,
+                    [this, ws] (const QPixmap& pixmap) {
+                showWaylandScreenshot(pixmap);
+                _lastSelectedArea = _selector->getSelectionRect();
+                _selector->deleteLater();
+                _selector = nullptr;
+                ws->deleteLater();
+            });
+        });
+        break;
+    }
+    default: // for now, we can take only a fullscreen shot
+    {
+        auto ws = new LXQt::Wayland::ScreenShot(_conf->getIncludeCursor(),
+                                                _wnd->selectedScreen(),
+                                                QRect(),
+                                                this);
+        connect(ws, &LXQt::Wayland::ScreenShot::screenShotReady, this,
+                [this, ws] (const QPixmap& pixmap) {
+            showWaylandScreenshot(pixmap);
+            ws->deleteLater();
+        });
+        break;
+    }
+    }
+}
+
+// Should be called only on Wayland.
+void Core::showWaylandScreenshot(const QPixmap& pixmap)
+{
+    if (!pixmap.isNull())
+    {
+        *_pixelMap = pixmap;
+        _wnd->updatePixmap(_pixelMap);
+        _wnd->restoreFromShot();
+    }
+    if (_firstScreen)
+    {
+        _wnd->resize(_conf->getRestoredWndSize());
+        if (runAsMinimized())
+        {
+            if (_wnd->isTrayed())
+                _wnd->windowHideShow();
+            else
+                _wnd->showMinimized();
+        }
+        else
+            _wnd->show();
+    }
 }
 
 void Core::checkAutoSave(bool first)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -125,6 +125,9 @@ private:
 
     void getFullScreenPixmap(QScreen* screen);
 
+    void waylandScreenShot();
+    void showWaylandScreenshot(const QPixmap& pixmap);
+
     QPixmap *_pixelMap; // pixel map
     RegionSelect *_selector; // region grabber widget
     QRect _lastSelectedArea;

--- a/src/core/regionselect.h
+++ b/src/core/regionselect.h
@@ -25,10 +25,12 @@
 #include <QWidget>
 
 #include <QMouseEvent>
+#include <QShowEvent>
 #include <QPainter>
 #include <QPixmap>
 #include <QSize>
 #include <QPoint>
+#include <QScreen>
 
 enum Side{
     TOP,
@@ -42,11 +44,13 @@ class RegionSelect : public QWidget
 {
     Q_OBJECT
 public:
-    RegionSelect(Config *mainconf, QWidget *parent = 0);
-    RegionSelect(Config *mainconf, const QRect& lastRect, QWidget *parent = 0);
+    RegionSelect(Config *mainconf, QScreen *screen = nullptr, QWidget *parent = nullptr);
+    RegionSelect(Config *mainconf, const QRect& lastRect, QScreen *screen = nullptr, QWidget *parent = nullptr);
     virtual ~RegionSelect();
-    QPixmap getSelection();
-    QPoint getSelectionStartPos();
+
+    QPixmap getSelection() const;
+    QRect getSelectionRect() const;
+    QPoint getSelectionStartPos() const;
 
 protected:
     void paintEvent(QPaintEvent *event);
@@ -55,6 +59,7 @@ protected:
     void mouseDoubleClickEvent(QMouseEvent *event);
     void mouseMoveEvent(QMouseEvent *event);
     void keyPressEvent(QKeyEvent *event);
+    void showEvent(QShowEvent *event);
 
 Q_SIGNALS:
     void processDone(bool grabbed);
@@ -86,6 +91,8 @@ private:
     QRectF widgetRect(const QRectF &pixmapRect) const;
 
     Config *_conf;
+
+    QScreen *_selectedScreen;
 
     const int fitRectExpand = 20;
     const int fitRectDepth = 50;

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -48,6 +48,7 @@ public:
     void updatePixmap(QPixmap *pMap);
     void updateModulesActions(const QList<QAction *> &list);
     void updateModulesMenus(const QList<QMenu *> &list);
+    QScreen* selectedScreen() const;
 
 public Q_SLOTS:
     void showWindow(const QString& str);

--- a/src/core/ui/mainwindow.ui
+++ b/src/core/ui/mainwindow.ui
@@ -68,6 +68,32 @@
        </spacer>
       </item>
       <item>
+       <widget class="QLabel" name="labScr">
+        <property name="text">
+         <string>Screen:</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QComboBox" name="cbxScr"/>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_6">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
        <widget class="QLabel" name="labTypeScr">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -163,6 +189,22 @@
          <number>90</number>
         </property>
        </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_7">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
       </item>
       <item>
        <spacer name="horizontalSpacer">

--- a/src/core/wayland/ScreenCopy.cpp
+++ b/src/core/wayland/ScreenCopy.cpp
@@ -1,0 +1,405 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Marcus Britanicus (https://gitlab.com/marcusbritanicus)
+ * Copyright (c) 2021 Abrar (https://gitlab.com/s96Abrar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ **/
+
+/**
+ * STEPS to obtain the screenshot
+ * 1. SCM requests to capture the output.
+ * 2. We get SCF object.
+ * 3. SCF emits a series of signals - one for each buffer format.
+ * 4. Once all formats are received, bufferDone is emitted.
+ * 5. Now, we can try to write the image.
+ *    a. Search if we have a suitable format.
+ *    b. Create the buffer for that format with suitable size, and stride
+ *    c. If buffer was created, then perform the copy() or copy_with_damage()
+ *    d. If we were successful, emit read(...) with the buffer object.
+ *       Otherwise, emit ready( nullptr ) along with failed().
+ * NOTE: If you called copy_with_damage(), i.e., copyWithDamage(), a series
+ * of damage(...) signals will be emitted to inform the user about the regions
+ * that were damaged before (and until) the copy was started. The net damage
+ * is the union of all the previous damage rects.
+ **/
+
+#include <errno.h>
+#include <fcntl.h>
+#include <limits.h>
+#include <png.h>
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/mman.h>
+#include <sys/param.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <assert.h>
+
+#include <QObject>
+#include <QDebug>
+#include <QImage>
+#include <QGuiApplication>
+
+#include <qpa/qplatformnativeinterface.h>
+
+#include "ScreenCopy.h"
+
+
+wl_output * getWlOutputFromQScreen( QScreen *screen ) {
+    if ( !screen ) {
+        qWarning( "Invalid QScreen pointer" );
+        return nullptr;
+    }
+
+    QPlatformNativeInterface *native = QGuiApplication::platformNativeInterface();
+
+    if ( !native ) {
+        qWarning( "Not a native platform application" );
+        return nullptr;
+    }
+
+    // Get the wl_output associated with this screen
+    void *output = native->nativeResourceForScreen( "output", screen );
+
+    if ( !output ) {
+        qWarning( "Failed to get wl_output for QScreen" );
+        return nullptr;
+    }
+
+    return static_cast<wl_output *>( output );
+}
+
+
+LXQt::Wayland::ScreenFrameBuffer::~ScreenFrameBuffer() {
+    if ( buffer ) {
+        wl_buffer_destroy( buffer );
+    }
+
+    if ( ( data != MAP_FAILED ) && data ) {
+        munmap( data, info.stride * info.height );
+    }
+}
+
+
+bool LXQt::Wayland::ScreenFrameBuffer::initializeBuffer( LXQt::Wayland::FrameBufferInfo bufInfo, wl_shm *shm ) {
+    // First, check if the new buffer info is different from the existing one
+    bool sameInfo = (
+        info.format == bufInfo.format &&
+        info.width == bufInfo.width &&
+        info.height == bufInfo.height &&
+        info.stride == bufInfo.stride
+    );
+
+    // If buffer exists and info is the same, return true
+    if ( sameInfo && ( buffer != nullptr ) ) {
+        return true;
+    }
+
+    // Clean up existing resources if parameters changed
+    if ( buffer ) {
+        wl_buffer_destroy( buffer );
+        buffer = nullptr;
+    }
+
+    if ( ( data != MAP_FAILED ) && data ) {
+        munmap( data, info.stride * info.height );
+        data = nullptr;
+    }
+
+    // Update info with new buffer parameters
+    info = bufInfo;
+
+    //qDebug() << "Creating fresh buffer";
+
+    int size = info.stride * info.height;
+
+    char shm_name[] = "/tmp/wayqt-screencopy-shared-XXXXXX";
+    int  fd         = mkstemp( shm_name );
+
+    // Handle potential EINTR during ftruncate
+    int ret;
+    do {
+        ret = ftruncate( fd, size );
+    } while ( ret == -1 && errno == EINTR );
+
+    if ( ret < 0 ) {
+        qCritical() << "Failed to create temporary file";
+
+        /** Failed to create backing file */
+        return false;
+    }
+
+    // Unlink immediately after creation for security
+    unlink( shm_name );
+
+    data = mmap( NULL, size, PROT_READ | PROT_WRITE, MAP_SHARED, fd, 0 );
+
+    if ( data == MAP_FAILED ) {
+        qCritical() << "Creating mmap failed:" << strerror( errno );
+        close( fd );
+
+        return false;
+    }
+
+    if ( shm == nullptr ) {
+        qCritical() << "Unable to allocate shared memory";
+
+        /** Release the mapped memory and close the fd */
+        munmap( data, size );
+        close( fd );
+
+        return false;
+    }
+
+    struct wl_shm_pool *pool = wl_shm_create_pool( shm, fd, size );
+
+    if ( pool == nullptr ) {
+        qCritical() << "Failed to create SHM pool";
+
+        /** Release the mapped memory and close the fd */
+        munmap( data, size );
+        close( fd );
+
+        return false;
+    }
+
+    /** Create the buffer */
+    buffer = wl_shm_pool_create_buffer( pool, 0, info.width, info.height, info.stride, info.format );
+
+    /** Destroy the pool */
+    wl_shm_pool_destroy( pool );
+    close( fd );
+
+    if ( buffer == nullptr ) {
+        qCritical() << "Failed to create Wayland buffer";
+
+        /** Release the mapped memory */
+        munmap( data, size );
+
+        return false;
+    }
+
+    /** Everything went on smoothly!! */
+    return true;
+}
+
+
+LXQt::Wayland::ScreenCopyManager::ScreenCopyManager( struct zwlr_screencopy_manager_v1 *mgr ) {
+    mObj = mgr;
+}
+
+
+LXQt::Wayland::ScreenCopyManager::~ScreenCopyManager() {
+    // Clean up screen buffers
+    qDeleteAll( mScreenBufferMap );
+    mScreenBufferMap.clear();
+
+    zwlr_screencopy_manager_v1_destroy( mObj );
+}
+
+
+LXQt::Wayland::ScreenCopyFrame *LXQt::Wayland::ScreenCopyManager::captureOutput( bool drawCursor, QScreen *screen ) {
+    wl_output *output = getWlOutputFromQScreen( screen );
+
+    if ( !output ) {
+        return nullptr;
+    }
+
+    struct zwlr_screencopy_frame_v1 *frame = zwlr_screencopy_manager_v1_capture_output( mObj, ( drawCursor ? 1 : 0 ), output );
+
+    return new ScreenCopyFrame( frame );
+}
+
+
+LXQt::Wayland::ScreenCopyFrame *LXQt::Wayland::ScreenCopyManager::captureOutputRegion( bool drawCursor, QScreen *screen, QRect rect ) {
+    wl_output *output = getWlOutputFromQScreen( screen );
+
+    if ( !output ) {
+        return nullptr;
+    }
+
+    struct zwlr_screencopy_frame_v1 *frame = zwlr_screencopy_manager_v1_capture_output_region(
+        mObj, ( drawCursor ? 1 : 0 ), output, rect.x(), rect.y(), rect.width(), rect.height()
+    );
+
+    return new ScreenCopyFrame( frame );
+}
+
+
+zwlr_screencopy_manager_v1 *LXQt::Wayland::ScreenCopyManager::get() {
+    return mObj;
+}
+
+
+LXQt::Wayland::ScreenCopyFrame::ScreenCopyFrame( zwlr_screencopy_frame_v1 *frame ) {
+    mObj = frame;
+
+    if ( wl_proxy_get_listener( (wl_proxy *)mObj ) != &mListener ) {
+        zwlr_screencopy_frame_v1_add_listener( mObj, &mListener, this );
+    }
+}
+
+
+LXQt::Wayland::ScreenCopyFrame::~ScreenCopyFrame() {
+    zwlr_screencopy_frame_v1_destroy( mObj );
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::setup() {
+    if ( mIsSetup == false ) {
+        mIsSetup = true;
+
+        if ( mBufferDonePending ) {
+            mBufferDonePending = false;
+            emit bufferDone();
+        }
+    }
+}
+
+
+QList<LXQt::Wayland::FrameBufferInfo> LXQt::Wayland::ScreenCopyFrame::availableFormats() {
+    return mReceivedBuffers;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::attachBuffer( LXQt::Wayland::ScreenFrameBuffer *buf ) {
+    mBuffer = buf;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::copy() {
+    if ( mBuffer == nullptr ) {
+        qWarning() << "No buffer attached. Call attachBuffer(...) before calling this function.";
+        return;
+    }
+
+    if ( mBuffer->buffer == nullptr ) {
+        qWarning() << "Failed to create buffer with format" << mBuffer->info.format;
+        return;
+    }
+
+    zwlr_screencopy_frame_v1_copy( mObj, mBuffer->buffer );
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::copyWithDamage() {
+    if ( mBuffer->buffer == nullptr ) {
+        qWarning() << "Failed to create buffer with format" << mBuffer->info.format;
+        return;
+    }
+
+    zwlr_screencopy_frame_v1_copy_with_damage( mObj, mBuffer->buffer );
+}
+
+
+zwlr_screencopy_frame_v1 *LXQt::Wayland::ScreenCopyFrame::get() {
+    return mObj;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleBuffer( void *data, struct zwlr_screencopy_frame_v1 *, uint32_t fmt, uint32_t w, uint32_t h, uint32_t stride ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+    FrameBufferInfo info       = { (wl_shm_format)fmt, w, h, stride };
+
+    scrnFrame->mReceivedBuffers << info;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleFlags( void *data, struct zwlr_screencopy_frame_v1 *, uint32_t flags ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+
+    scrnFrame->mYInvert = flags & ZWLR_SCREENCOPY_FRAME_V1_FLAGS_Y_INVERT;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleReady( void *data, struct zwlr_screencopy_frame_v1 *, uint32_t secs_hi, uint32_t secs_lo, uint32_t nsecs ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+
+    scrnFrame->mBuffer->time.secs  = ( ( 1ll * secs_hi ) << 32ll ) | secs_lo;
+    scrnFrame->mBuffer->time.nsecs = nsecs;
+
+    emit scrnFrame->ready( scrnFrame->mBuffer );
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleFailed( void *data, struct zwlr_screencopy_frame_v1 * ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+    emit scrnFrame->failed();
+
+    zwlr_screencopy_frame_v1_destroy( scrnFrame->mObj );
+    scrnFrame->mObj = nullptr;
+
+    emit scrnFrame->ready( nullptr );
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleDamage( void *data, struct zwlr_screencopy_frame_v1 *, uint32_t x, uint32_t y, uint32_t w, uint32_t h ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+
+    emit scrnFrame->damage( QRect( x, y, w, h ) );
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleLinuxDmabuf( void *data, struct zwlr_screencopy_frame_v1 *, uint32_t format, uint32_t width, uint32_t height ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+
+    // Log that Linux DmaBuf is available
+    //qDebug() << "Linux DmaBuf frame available:" << "Format:" << format << "Width:" << width << "Height:" << height;
+
+    // Emit a signal to notify about Linux DmaBuf availability
+    emit scrnFrame->linuxDmabuf();
+
+    // Optional: Add the DmaBuf format to received buffers
+    FrameBufferInfo dmabufInfo = {
+        static_cast<wl_shm_format>( format ),
+        width,
+        height,
+        width * 4  // Assuming 4 bytes per pixel, adjust as needed
+    };
+    scrnFrame->mReceivedBuffers << dmabufInfo;
+}
+
+
+void LXQt::Wayland::ScreenCopyFrame::handleBufferDone( void *data, struct zwlr_screencopy_frame_v1 * ) {
+    ScreenCopyFrame *scrnFrame = reinterpret_cast<ScreenCopyFrame *>( data );
+
+    if ( scrnFrame->mIsSetup ) {
+        emit scrnFrame->bufferDone();
+    }
+
+    else {
+        scrnFrame->mBufferDonePending = true;
+    }
+}
+
+
+const zwlr_screencopy_frame_v1_listener LXQt::Wayland::ScreenCopyFrame::mListener = {
+    handleBuffer,
+    handleFlags,
+    handleReady,
+    handleFailed,
+    handleDamage,
+    handleLinuxDmabuf,
+    handleBufferDone,
+};

--- a/src/core/wayland/ScreenCopy.h
+++ b/src/core/wayland/ScreenCopy.h
@@ -1,0 +1,172 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Marcus Britanicus (https://gitlab.com/marcusbritanicus)
+ * Copyright (c) 2021 Abrar (https://gitlab.com/s96Abrar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ **/
+
+#pragma once
+
+#include <QMap>
+#include <QRect>
+#include <QImage>
+#include <QObject>
+#include <QScreen>
+#include <QString>
+#include <wayland-client-protocol.h>
+
+#include <wayland-client.h>
+#include "wayland-wlr-screencopy-unstable-v1-client-protocol.h"
+
+
+struct wl_buffer;
+struct wl_output;
+struct wl_shm;
+
+namespace LXQt {
+    namespace Wayland {
+        class ScreenCopyManager;
+        class ScreenCopyFrame;
+
+        typedef struct _bufferInfo {
+            enum wl_shm_format format;
+            uint32_t width;
+            uint32_t height;
+            uint32_t stride;
+        } FrameBufferInfo;
+
+        typedef struct _time_stamp_t {
+            uint32_t secs  = 0;
+            uint32_t nsecs = 0;
+        } BufferTimeStamp;
+
+        typedef struct _buffer {
+            struct wl_buffer *buffer = nullptr;
+            void             *data   = nullptr;
+            FrameBufferInfo  info;
+            BufferTimeStamp  time;
+
+            ~_buffer();
+            bool initializeBuffer( FrameBufferInfo, wl_shm *shm );
+        } ScreenFrameBuffer;
+    }
+}
+
+class LXQt::Wayland::ScreenCopyManager : public QObject {
+    Q_OBJECT;
+
+    public:
+        ScreenCopyManager( struct ::zwlr_screencopy_manager_v1 *scrnMgr );
+        ~ScreenCopyManager();
+
+        /**
+         * Capture an output.
+         * The first argument allows the user to choose if the mouse pointer needs to be drawn
+         */
+        ScreenCopyFrame *captureOutput( bool, QScreen * );
+
+        /**
+         * Capture a region of an output.
+         * The first argument allows the user to choose if the mouse pointer needs to be drawn
+         */
+        ScreenCopyFrame *captureOutputRegion( bool, QScreen *, QRect );
+
+        struct zwlr_screencopy_manager_v1 *get();
+
+    private:
+        /** Create a shared memory buffer */
+        struct wl_buffer *createShmBuffer( FrameBufferInfo, void ** );
+
+        /** Raw zwlr_screencopy_manager_v1 pointer */
+        struct zwlr_screencopy_manager_v1 *mObj;
+
+        /** A map of screen names and buffers */
+        QMap<QString, LXQt::Wayland::ScreenFrameBuffer *> mScreenBufferMap;
+};
+
+class LXQt::Wayland::ScreenCopyFrame : public QObject {
+    Q_OBJECT;
+
+    public:
+        enum Error {
+            AlreadyUsed = 0,
+            InvalidBuffer
+        };
+
+        ScreenCopyFrame( struct ::zwlr_screencopy_frame_v1 * );
+        ~ScreenCopyFrame();
+
+        /** Setup the listener. First connect the signals to your slots, and then call this */
+        void setup();
+
+        QList<FrameBufferInfo> availableFormats();
+
+        /** Attach the screen buffer to this object */
+        void attachBuffer( LXQt::Wayland::ScreenFrameBuffer *buf );
+
+        /** Copy the whole frame */
+        void copy();
+
+        /** Wait for damage and then copy the damaged rect only */
+        void copyWithDamage();
+
+        struct zwlr_screencopy_frame_v1 *get();
+
+    private:
+        static void handleBuffer( void *, struct zwlr_screencopy_frame_v1 *, uint32_t, uint32_t, uint32_t, uint32_t );
+        static void handleFlags( void *, struct zwlr_screencopy_frame_v1 *, uint32_t );
+        static void handleReady( void *, struct zwlr_screencopy_frame_v1 *, uint32_t, uint32_t, uint32_t );
+        static void handleFailed( void *, struct zwlr_screencopy_frame_v1 * );
+        static void handleDamage( void *, struct zwlr_screencopy_frame_v1 *, uint32_t, uint32_t, uint32_t, uint32_t );
+        static void handleLinuxDmabuf( void *, struct zwlr_screencopy_frame_v1 *, uint32_t, uint32_t, uint32_t );
+        static void handleBufferDone( void *, struct zwlr_screencopy_frame_v1 * );
+
+        static const struct zwlr_screencopy_frame_v1_listener mListener;
+
+        zwlr_screencopy_frame_v1 *mObj;
+
+        bool mIsSetup           = false;
+        bool mBufferDonePending = false;
+
+        /** We handle only the following formats */
+        QList<wl_shm_format> mFormats {
+            WL_SHM_FORMAT_XRGB8888,
+            WL_SHM_FORMAT_ARGB8888,
+            WL_SHM_FORMAT_XBGR8888,
+            WL_SHM_FORMAT_ABGR8888,
+        };
+
+        QList<FrameBufferInfo> mReceivedBuffers;
+        ScreenFrameBuffer *mBuffer = nullptr;
+        QRectF mDamage;
+
+        bool mYInvert  = false;
+        bool mCopyDone = false;
+        bool mFailed   = false;
+
+    Q_SIGNALS:
+        void ready( LXQt::Wayland::ScreenFrameBuffer * );
+        void format( uint32_t );
+        void failed();
+        void damage( QRect );
+        void linuxDmabuf();
+        void bufferDone();
+};

--- a/src/core/wayland/ScreenShot.cpp
+++ b/src/core/wayland/ScreenShot.cpp
@@ -1,0 +1,184 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Marcus Britanicus (https://gitlab.com/marcusbritanicus)
+ * Copyright (c) 2021 Abrar (https://gitlab.com/s96Abrar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ **/
+
+#include <wayland-client.h>
+#include "ScreenShot.h"
+#include "ScreenCopy.h"
+
+#include <QGuiApplication>
+#include <QPixmap>
+#include <QTimer>
+#include <QDebug>
+
+#include <QtGui/private/qguiapplication_p.h>
+#include <QtWaylandClient/private/qwaylandintegration_p.h>
+#include <QtWaylandClient/private/qwaylanddisplay_p.h>
+
+QMap<wl_shm_format, QImage::Format> mFormats{
+    { WL_SHM_FORMAT_XRGB8888, QImage::Format_ARGB32 },
+    { WL_SHM_FORMAT_ARGB8888, QImage::Format_ARGB32 },
+    { WL_SHM_FORMAT_XBGR8888, QImage::Format_RGBA8888 },
+    { WL_SHM_FORMAT_ABGR8888, QImage::Format_RGBA8888 },
+};
+
+LXQt::Wayland::ScreenShot::ScreenShot(bool drawCursor, QScreen *screen, const QRect &rect, QObject *parent) :
+    QObject (parent),
+    scrnCopyMgr(nullptr)  {
+
+    /** Get the QWaylandDisplay object. We can do everything else from here. */
+    QtWaylandClient::QWaylandDisplay *qDisplay = nullptr;
+    QtWaylandClient::QWaylandIntegration *waylandIntegration =
+        static_cast<QtWaylandClient::QWaylandIntegration *>(QGuiApplicationPrivate::platformIntegration());
+    if (waylandIntegration) {
+        qDisplay = waylandIntegration->display();
+    }
+    if (qDisplay == nullptr)
+    {
+        qCritical() << "Failed to get Wayland display";
+        QTimer::singleShot(0, this, [this]() {
+            Q_EMIT screenShotReady(QPixmap());
+        });
+        return;
+    }
+
+    wl_shm *shm = nullptr;
+
+    //qDebug() << "Using Wayland display:" << qDisplay->display();
+    //qDebug() << qDisplay->screens();
+
+
+    // qDisplay->initialize();
+
+    /*QEventLoop loop;
+
+    QObject::connect(
+        qDisplay, &QtWaylandClient::QWaylandDisplay::globalAdded, [ &loop ] ( const QtWaylandClient::QWaylandDisplay::RegistryGlobal& global ) {
+            qDebug() << global.interface << "added";
+
+            if ( ( global.interface == zwlr_screencopy_manager_v1_interface.name ) && ( scrnCopyMgr == nullptr ) ) {
+                zwlr_screencopy_manager_v1 *wlrScreenCopyMgr = (zwlr_screencopy_manager_v1 *)wl_registry_bind( global.registry, global.id, &zwlr_screencopy_manager_v1_interface, 3 );
+
+                if ( wlrScreenCopyMgr ) {
+                    scrnCopyMgr = new LXQt::Wayland::ScreenCopyManager( wlrScreenCopyMgr );
+                }
+
+                loop.quit();
+            }
+
+            else if ( global.interface == wl_shm_interface.name ) {
+                shm = (wl_shm *)wl_registry_bind( global.registry, global.id, &wl_shm_interface, global.version );
+            }
+        }
+    );*/
+
+    for (QtWaylandClient::QWaylandDisplay::RegistryGlobal global: qDisplay->globals())
+    {
+        if (global.interface == QString::fromUtf8(zwlr_screencopy_manager_v1_interface.name))
+        {
+            zwlr_screencopy_manager_v1 *wlrScreenCopyMgr = (zwlr_screencopy_manager_v1 *)wl_registry_bind(global.registry, global.id, &zwlr_screencopy_manager_v1_interface, 3);
+
+            if (wlrScreenCopyMgr)
+            {
+                scrnCopyMgr = new LXQt::Wayland::ScreenCopyManager(wlrScreenCopyMgr);
+                //qDebug() << "Ready";
+            }
+        }
+        else if (global.interface == QString::fromUtf8(wl_shm_interface.name))
+        {
+            shm = (wl_shm *)wl_registry_bind(global.registry, global.id, &wl_shm_interface, global.version);
+        }
+    }
+
+    /*if ( ( scrnCopyMgr == nullptr ) || ( shm == nullptr ) ) {
+        loop.exec();
+    }*/
+
+    if (scrnCopyMgr == nullptr || shm == nullptr)
+    {
+        QTimer::singleShot(0, this, [this]() {
+            Q_EMIT screenShotReady(QPixmap());
+        });
+        return;
+    }
+
+
+    LXQt::Wayland::ScreenCopyFrame *frame =
+        rect.isEmpty() ? scrnCopyMgr->captureOutput(drawCursor, screen)
+                       : scrnCopyMgr->captureOutputRegion(drawCursor, screen, rect);
+
+    if ( frame == nullptr )
+    {
+        QTimer::singleShot(0, this, [this]() {
+            Q_EMIT screenShotReady(QPixmap());
+        });
+        return;
+    }
+
+    LXQt::Wayland::ScreenFrameBuffer *buffer = new LXQt::Wayland::ScreenFrameBuffer;
+
+    QObject::connect(frame, &LXQt::Wayland::ScreenCopyFrame::bufferDone, this, [frame, buffer, shm]() {
+        for (LXQt::Wayland::FrameBufferInfo info: frame->availableFormats())
+        {
+            if (mFormats.contains(info.format))
+            {
+                buffer->initializeBuffer(info, shm);
+
+                if (buffer->buffer == nullptr)
+                {
+                    qWarning() << "Failed to create buffer with format" << buffer->info.format;
+                    continue;
+                }
+
+                frame->attachBuffer(buffer);
+                frame->copy();
+            }
+        }
+    });
+
+    QObject::connect(frame, &LXQt::Wayland::ScreenCopyFrame::ready, this, [this, screen]
+                     (LXQt::Wayland::ScreenFrameBuffer *buffer) {
+        if (buffer == nullptr)
+        {
+            //qDebug() << "Screenshot failed";
+            Q_EMIT screenShotReady(QPixmap());
+            return;
+        }
+        QImage img((uchar *)buffer->data,
+                   buffer->info.width,
+                   buffer->info.height,
+                   buffer->info.stride,
+                   mFormats[buffer->info.format]);
+        QPixmap px;
+        px.convertFromImage(img);
+        Q_EMIT screenShotReady(px);
+    });
+
+    frame->setup();
+}
+
+LXQt::Wayland::ScreenShot::~ScreenShot() {
+    delete scrnCopyMgr;
+    scrnCopyMgr = nullptr;
+}

--- a/src/core/wayland/ScreenShot.h
+++ b/src/core/wayland/ScreenShot.h
@@ -1,0 +1,53 @@
+/**
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021 Marcus Britanicus (https://gitlab.com/marcusbritanicus)
+ * Copyright (c) 2021 Abrar (https://gitlab.com/s96Abrar)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ **/
+
+#pragma once
+
+#include <QtWidgets>
+
+#include <wayland-client.h>
+#include "ScreenCopy.h"
+
+class QScreen;
+class QPixmap;
+
+namespace LXQt {
+    namespace Wayland {
+        class ScreenShot : public QObject {
+            Q_OBJECT;
+
+        public:
+            ScreenShot(bool drawCursor, QScreen *screen, const QRect &rect, QObject *parent = nullptr);
+            ~ScreenShot();
+
+        Q_SIGNALS:
+            void screenShotReady(const QPixmap& pixmap);
+
+        private:
+            ScreenCopyManager *scrnCopyMgr;
+
+        };
+    }
+}

--- a/src/core/wayland/wlr-screencopy-unstable-v1.xml
+++ b/src/core/wayland/wlr-screencopy-unstable-v1.xml
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<protocol name="wlr_screencopy_unstable_v1">
+  <copyright>
+    Copyright © 2018 Simon Ser
+    Copyright © 2019 Andri Yngvason
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice (including the next
+    paragraph) shall be included in all copies or substantial portions of the
+    Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.  IN NO EVENT SHALL
+    THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE.
+  </copyright>
+
+  <description summary="screen content capturing on client buffers">
+    This protocol allows clients to ask the compositor to copy part of the
+    screen content to a client buffer.
+
+    Warning! The protocol described in this file is experimental and
+    backward incompatible changes may be made. Backward compatible changes
+    may be added together with the corresponding interface version bump.
+    Backward incompatible changes are done by bumping the version number in
+    the protocol and interface names and resetting the interface version.
+    Once the protocol is to be declared stable, the 'z' prefix and the
+    version number in the protocol and interface names are removed and the
+    interface version number is reset.
+  </description>
+
+  <interface name="zwlr_screencopy_manager_v1" version="3">
+    <description summary="manager to inform clients and begin capturing">
+      This object is a manager which offers requests to start capturing from a
+      source.
+    </description>
+
+    <request name="capture_output">
+      <description summary="capture an output">
+        Capture the next frame of an entire output.
+      </description>
+      <arg name="frame" type="new_id" interface="zwlr_screencopy_frame_v1"/>
+      <arg name="overlay_cursor" type="int"
+        summary="composite cursor onto the frame"/>
+      <arg name="output" type="object" interface="wl_output"/>
+    </request>
+
+    <request name="capture_output_region">
+      <description summary="capture an output's region">
+        Capture the next frame of an output's region.
+
+        The region is given in output logical coordinates, see
+        xdg_output.logical_size. The region will be clipped to the output's
+        extents.
+      </description>
+      <arg name="frame" type="new_id" interface="zwlr_screencopy_frame_v1"/>
+      <arg name="overlay_cursor" type="int"
+        summary="composite cursor onto the frame"/>
+      <arg name="output" type="object" interface="wl_output"/>
+      <arg name="x" type="int"/>
+      <arg name="y" type="int"/>
+      <arg name="width" type="int"/>
+      <arg name="height" type="int"/>
+    </request>
+
+    <request name="destroy" type="destructor">
+      <description summary="destroy the manager">
+        All objects created by the manager will still remain valid, until their
+        appropriate destroy request has been called.
+      </description>
+    </request>
+  </interface>
+
+  <interface name="zwlr_screencopy_frame_v1" version="3">
+    <description summary="a frame ready for copy">
+      This object represents a single frame.
+
+      When created, a series of buffer events will be sent, each representing a
+      supported buffer type. The "buffer_done" event is sent afterwards to
+      indicate that all supported buffer types have been enumerated. The client
+      will then be able to send a "copy" request. If the capture is successful,
+      the compositor will send a "flags" followed by a "ready" event.
+
+      For objects version 2 or lower, wl_shm buffers are always supported, ie.
+      the "buffer" event is guaranteed to be sent.
+
+      If the capture failed, the "failed" event is sent. This can happen anytime
+      before the "ready" event.
+
+      Once either a "ready" or a "failed" event is received, the client should
+      destroy the frame.
+    </description>
+
+    <event name="buffer">
+      <description summary="wl_shm buffer information">
+        Provides information about wl_shm buffer parameters that need to be
+        used for this frame. This event is sent once after the frame is created
+        if wl_shm buffers are supported.
+      </description>
+      <arg name="format" type="uint" enum="wl_shm.format" summary="buffer format"/>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+      <arg name="stride" type="uint" summary="buffer stride"/>
+    </event>
+
+    <request name="copy">
+      <description summary="copy the frame">
+        Copy the frame to the supplied buffer. The buffer must have a the
+        correct size, see zwlr_screencopy_frame_v1.buffer and
+        zwlr_screencopy_frame_v1.linux_dmabuf. The buffer needs to have a
+        supported format.
+
+        If the frame is successfully copied, a "flags" and a "ready" events are
+        sent. Otherwise, a "failed" event is sent.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+
+    <enum name="error">
+      <entry name="already_used" value="0"
+        summary="the object has already been used to copy a wl_buffer"/>
+      <entry name="invalid_buffer" value="1"
+        summary="buffer attributes are invalid"/>
+    </enum>
+
+    <enum name="flags" bitfield="true">
+      <entry name="y_invert" value="1" summary="contents are y-inverted"/>
+    </enum>
+
+    <event name="flags">
+      <description summary="frame flags">
+        Provides flags about the frame. This event is sent once before the
+        "ready" event.
+      </description>
+      <arg name="flags" type="uint" enum="flags" summary="frame flags"/>
+    </event>
+
+    <event name="ready">
+      <description summary="indicates frame is available for reading">
+        Called as soon as the frame is copied, indicating it is available
+        for reading. This event includes the time at which presentation happened
+        at.
+
+        The timestamp is expressed as tv_sec_hi, tv_sec_lo, tv_nsec triples,
+        each component being an unsigned 32-bit value. Whole seconds are in
+        tv_sec which is a 64-bit value combined from tv_sec_hi and tv_sec_lo,
+        and the additional fractional part in tv_nsec as nanoseconds. Hence,
+        for valid timestamps tv_nsec must be in [0, 999999999]. The seconds part
+        may have an arbitrary offset at start.
+
+        After receiving this event, the client should destroy the object.
+      </description>
+      <arg name="tv_sec_hi" type="uint"
+           summary="high 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_sec_lo" type="uint"
+           summary="low 32 bits of the seconds part of the timestamp"/>
+      <arg name="tv_nsec" type="uint"
+           summary="nanoseconds part of the timestamp"/>
+    </event>
+
+    <event name="failed">
+      <description summary="frame copy failed">
+        This event indicates that the attempted frame copy has failed.
+
+        After receiving this event, the client should destroy the object.
+      </description>
+    </event>
+
+    <request name="destroy" type="destructor">
+      <description summary="delete this object, used or not">
+        Destroys the frame. This request can be sent at any time by the client.
+      </description>
+    </request>
+
+    <!-- Version 2 additions -->
+    <request name="copy_with_damage" since="2">
+      <description summary="copy the frame when it's damaged">
+        Same as copy, except it waits until there is damage to copy.
+      </description>
+      <arg name="buffer" type="object" interface="wl_buffer"/>
+    </request>
+
+    <event name="damage" since="2">
+      <description summary="carries the coordinates of the damaged region">
+        This event is sent right before the ready event when copy_with_damage is
+        requested. It may be generated multiple times for each copy_with_damage
+        request.
+
+        The arguments describe a box around an area that has changed since the
+        last copy request that was derived from the current screencopy manager
+        instance.
+
+        The union of all regions received between the call to copy_with_damage
+        and a ready event is the total damage since the prior ready event.
+      </description>
+      <arg name="x" type="uint" summary="damaged x coordinates"/>
+      <arg name="y" type="uint" summary="damaged y coordinates"/>
+      <arg name="width" type="uint" summary="current width"/>
+      <arg name="height" type="uint" summary="current height"/>
+    </event>
+
+    <!-- Version 3 additions -->
+    <event name="linux_dmabuf" since="3">
+      <description summary="linux-dmabuf buffer information">
+        Provides information about linux-dmabuf buffer parameters that need to
+        be used for this frame. This event is sent once after the frame is
+        created if linux-dmabuf buffers are supported.
+      </description>
+      <arg name="format" type="uint" summary="fourcc pixel format"/>
+      <arg name="width" type="uint" summary="buffer width"/>
+      <arg name="height" type="uint" summary="buffer height"/>
+    </event>
+
+    <event name="buffer_done" since="3">
+      <description summary="all buffer types reported">
+        This event is sent once after all buffer events have been sent.
+
+        The client should proceed to create a buffer of one of the supported
+        types, and send a "copy" request.
+      </description>
+    </event>
+  </interface>
+</protocol>


### PR DESCRIPTION
All credits go to @marcusbritanicus, who wrote the code for supporting the wlr screencopy protocol. Any probable mistake is mine.

His code has been used here for taking fullscreen and area screenshots under Wayland compositors that support the above-mentioned protocol.

For now,

 * With multiple screens, the first shot is taken from the first (= leftmost/topmost) screen, but the screen can be selected for the subsequent shots from a new combo-box which appears only when there are multiple screens on Wayland. If desirable, the selected screen could be remembered in another PR.
 * A window screenshot isn't possible yet. Although its item is still shown, it takes a fullscreen shot. I'll remove it for Wayland in another PR.
 * Zooming and fitting aren't possible either. The check-box for zooming isn't shown under Wayland.

NOTE: I think the licenses of the new files should be changed (in this PR). Please tell me how.