### PR TITLE
Cleaned up GUI/code and added an option for Wayland

### DIFF
--- a/src/core/config.cpp
+++ b/src/core/config.cpp
@@ -35,6 +35,7 @@
 #define KEY_SAVEFORMAT          "defImgFormat"
 #define KEY_DELAY               "delay"
 #define KEY_SCREENSHOT_TYPE_DEF "defScreenshotType"
+#define KEY_SCREEN              "defScreen"
 #define KEY_IMG_QUALITY         "imageQuality"
 #define KEY_FILENAMEDATE        "insDateTimeInFilename"
 #define KEY_DATETIME_TPL        "templateDateTime"
@@ -55,8 +56,8 @@
 #define KEY_NODECOR             "noDecorations"
 #define KEY_INCLUDE_CURSOR      "includeCursor"
 #define KEY_FIT_INSIDE          "fitInside"
-
-#define KEY_LAST_SELECTION          "lastSelection"
+#define KEY_REM_LAST_SCREEN     "remLastScreen"
+#define KEY_LAST_SELECTION      "lastSelection"
 
 
 static const QLatin1String FullScreen("FullScreen");
@@ -275,6 +276,16 @@ void Config::setDefScreenshotType(const int type)
     setValue(QLatin1String(KEY_SCREENSHOT_TYPE_DEF), type);
 }
 
+QString Config::getScreen()
+{
+    return (value(QLatin1String(KEY_SCREEN)).toString());
+}
+
+void Config::setScreen(const QString &screen)
+{
+    setValue(QLatin1String(KEY_SCREEN), screen);
+}
+
 quint8 Config::getAutoCopyFilenameOnSaving()
 {
     return value(QLatin1String(KEY_FILENAME_TO_CLB)).toInt();
@@ -427,6 +438,16 @@ void Config::setFitInside(bool val)
     setValue(QLatin1String(KEY_FIT_INSIDE), val);
 }
 
+bool Config::getRemLastScreen()
+{
+    return value(QLatin1String(KEY_REM_LAST_SCREEN)).toBool();
+}
+
+void Config::setRemLastScreen(bool val)
+{
+    setValue(QLatin1String(KEY_REM_LAST_SCREEN), val);
+}
+
 QRect Config::getLastSelection()
 {
     return value(QLatin1String(KEY_LAST_SELECTION)).toRect();
@@ -455,6 +476,7 @@ void Config::loadSettings()
     setSaveFormat(_settings->value(QLatin1String(KEY_SAVEFORMAT), DEF_SAVE_FORMAT).toString());
     setDelay(_settings->value(QLatin1String(KEY_DELAY), DEF_DELAY).toInt());
     setDefScreenshotType(screenshotTypeFromString(_settings->value(QLatin1String(KEY_SCREENSHOT_TYPE_DEF)).toString()));
+    setScreen(_settings->value(QLatin1String(KEY_SCREEN)).toString());
     setAutoCopyFilenameOnSaving(_settings->value(QLatin1String(KEY_FILENAME_TO_CLB), DEF_FILENAME_TO_CLB).toInt());
     setDateTimeInFilename(_settings->value(QLatin1String(KEY_FILENAMEDATE), DEF_DATETIME_FILENAME).toBool());
     setDateTimeTpl(_settings->value(QLatin1String(KEY_DATETIME_TPL), DEF_DATETIME_TPL).toString());
@@ -481,6 +503,7 @@ void Config::loadSettings()
     setAllowMultipleInstance(_settings->value(QLatin1String(KEY_ALLOW_COPIES), DEF_ALLOW_COPIES).toBool());
     setEnableExtView(_settings->value(QLatin1String(KEY_ENABLE_EXT_VIEWER), DEF_ENABLE_EXT_VIEWER).toBool());
     setFitInside(_settings->value(QLatin1String(KEY_FIT_INSIDE), DEF_FIT_INSIDE).toBool());
+    setRemLastScreen(_settings->value(QLatin1String(KEY_REM_LAST_SCREEN), DEF_REM_LAST_SCREEN).toBool());
     _settings->endGroup();
 
     _shortcuts->loadSettings();
@@ -512,6 +535,7 @@ void Config::saveSettings()
     _settings->setValue(QLatin1String(KEY_ALLOW_COPIES), getAllowMultipleInstance());
     _settings->setValue(QLatin1String(KEY_ENABLE_EXT_VIEWER), getEnableExtView());
     _settings->setValue(QLatin1String(KEY_FIT_INSIDE), getFitInside());
+    _settings->setValue(QLatin1String(KEY_REM_LAST_SCREEN), getRemLastScreen());
     _settings->endGroup();
 
     _shortcuts->saveSettings();
@@ -523,6 +547,8 @@ void Config::saveScreenshotSettings()
 { // save the main window settings
     _settings->beginGroup(QStringLiteral("Base"));
     _settings->setValue(QLatin1String(KEY_SCREENSHOT_TYPE_DEF), screenshotTypeToString(getDefScreenshotType()));
+    if (getRemLastScreen()) // save it only if needed
+        _settings->setValue(QLatin1String(KEY_SCREEN), getScreen());
     _settings->setValue(QLatin1String(KEY_NODECOR), getNoDecoration());
     _settings->setValue(QLatin1String(KEY_INCLUDE_CURSOR), getIncludeCursor());
     _settings->setValue(QLatin1String(KEY_DELAY), getDelay());

--- a/src/core/config.h
+++ b/src/core/config.h
@@ -51,6 +51,7 @@ const bool DEF_SHOW_TRAY = true;
 const bool DEF_ENABLE_EXT_VIEWER = true;
 const bool DEF_INCLUDE_CURSOR = false;
 const bool DEF_FIT_INSIDE = true;
+const bool DEF_REM_LAST_SCREEN = false;
 
 class Settings : public QSettings // prevents redundant writings
 {
@@ -158,6 +159,10 @@ public:
     int getDefScreenshotType();
     void setDefScreenshotType(const int type);
 
+    // last screen name (only for Wayland)
+    QString getScreen();
+    void setScreen(const QString &screen);
+
     quint8 getAutoCopyFilenameOnSaving();
     void setAutoCopyFilenameOnSaving(quint8 val);
 
@@ -232,6 +237,10 @@ public:
 
     bool getFitInside();
     void setFitInside(bool val);
+
+    // whether the last screen should be remembered (only for Wayland)
+    bool getRemLastScreen();
+    void setRemLastScreen(bool val);
 
     QRect getLastSelection();
     void setLastSelection(QRect rect);

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -107,6 +107,7 @@ Core* Core::instance()
 Core::~Core()
 {
     killTempFile();
+    delete _selector;
     delete _pixelMap;
     _conf->killInstance();
 }
@@ -336,6 +337,8 @@ void Core::showWaylandScreenshot(const QPixmap& pixmap)
         else
             _wnd->show();
     }
+    else if (pixmap.isNull())
+        _wnd->restoreFromShot();
 }
 
 void Core::checkAutoSave(bool first)
@@ -704,4 +707,5 @@ void Core::regionGrabbed(bool grabbed)
 
     _wnd->updatePixmap(_pixelMap);
     _selector->deleteLater();
+    _selector = nullptr;
 }

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -156,7 +156,8 @@ void Core::coreQuit()
     if (_wnd) {
         _conf->setRestoredWndSize(_wnd->width(), _wnd->height());
         _conf->saveWndSize();
-        _wnd->close();
+        if (_wnd->isVisible())
+            _wnd->close();
     }
 
     if (corePtr)

--- a/src/core/regionselect.cpp
+++ b/src/core/regionselect.cpp
@@ -146,11 +146,10 @@ void RegionSelect::paintEvent(QPaintEvent *event)
     else if (!_processSelection)
     { // the tip should be drawn here because the overlay is transparent under Wayland
         static const QString tip = QApplication::tr("Click and drag to draw a rectangle,\ndouble click or press Enter\nto take a screenshot,\nor press Escape to cancel.");
-        QRect txtRect = rect();
-        txtRect.setHeight(qRound((static_cast<float>(txtRect.height()) / 10)));
-        QRect txtBgRect = painter.boundingRect(txtRect, Qt::AlignCenter, tip);
-        txtBgRect.setX(txtBgRect.x() - 6);
-        txtBgRect.setY(txtBgRect.y() - 6);
+        QRect txtBgRect = painter.boundingRect(rect(), Qt::AlignHCenter | Qt::AlignTop, tip);
+        txtBgRect.moveTop(50);
+        txtBgRect.setLeft(txtBgRect.x() - 6);
+        txtBgRect.setTop(txtBgRect.y() - 6);
         txtBgRect.setWidth(txtBgRect.width() + 12);
         txtBgRect.setHeight(txtBgRect.height() + 12);
         painter.save();

--- a/src/core/regionselect.cpp
+++ b/src/core/regionselect.cpp
@@ -81,12 +81,13 @@ void RegionSelect::sharedInit()
     setWindowFlags(Qt::FramelessWindowHint | Qt::WindowStaysOnTopHint | Qt::X11BypassWindowManagerHint);
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
         setAttribute(Qt::WA_TranslucentBackground);
+    // Setting the state to fullscreen is safe with Wayland too
+    // (and tells Kvantum not to apply KWin's blur effect).
+    setWindowState(Qt::WindowFullScreen);
     setCursor(Qt::CrossCursor);
 
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
         return;
-
-    setWindowState(Qt::WindowFullScreen);
 
     auto screen = QGuiApplication::screenAt(QCursor::pos());
     if (screen == nullptr)

--- a/src/core/ui/configwidget.cpp
+++ b/src/core/ui/configwidget.cpp
@@ -60,6 +60,11 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     void (QComboBox::*formatChabge)(int) = &QComboBox::currentIndexChanged;
     connect(_ui->cbxFormat, formatChabge, this, &ConfigDialog::changeFormatType);
 
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+        _ui->checkFitInside->hide();
+    else
+        _ui->checkLastScreen->hide();
+
     loadSettings();
     setVisibleDateTplEdit(conf->getDateTimeInFilename());
 
@@ -138,6 +143,8 @@ void ConfigDialog::loadSettings()
     _ui->cbxEnableExtView->setChecked(conf->getEnableExtView());
 
     _ui->checkFitInside->setChecked(conf->getFitInside());
+
+    _ui->checkLastScreen->setChecked(conf->getRemLastScreen());
 }
 
 
@@ -218,6 +225,7 @@ void ConfigDialog::saveSettings()
     conf->setImageQuality(_ui->slideImgQuality->value());
     conf->setEnableExtView(_ui->cbxEnableExtView->isChecked());
     conf->setFitInside(_ui->checkFitInside->isChecked());
+    conf->setRemLastScreen(_ui->checkLastScreen->isChecked());
 
     // save shortcuts in shortcutmanager
     int action = 3; // starting with shortcutNew

--- a/src/core/ui/configwidget.cpp
+++ b/src/core/ui/configwidget.cpp
@@ -46,9 +46,6 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
     connect(_ui->checkShowTray, &QCheckBox::toggled, this, &ConfigDialog::toggleCheckShowTray);
     connect(_ui->editDateTmeTpl, &QLineEdit::textEdited, this, &ConfigDialog::editDateTmeTpl);
 
-    connect(_ui->checkNotify, &QGroupBox::clicked, this, &ConfigDialog::showNotification);
-    connect(_ui->spinDuration, &QSpinBox::valueChanged, this, &ConfigDialog::changeNotificationTimeout);
-
     connect(_ui->treeKeys, &QTreeWidget::doubleClicked, this, &ConfigDialog::doubleclickTreeKeys);
     connect(_ui->treeKeys, &QTreeWidget::activated, this, &ConfigDialog::doubleclickTreeKeys);
     connect(_ui->treeKeys->selectionModel(), &QItemSelectionModel::currentChanged,
@@ -288,16 +285,6 @@ void ConfigDialog::restoreDefaults()
         conf->saveSettings();
         QDialog::accept();
     }
-}
-
-void ConfigDialog::showNotification(bool show)
-{
-    conf->showNotification(show);
-}
-
-void ConfigDialog::changeNotificationTimeout(int sec)
-{
-    conf->setNotificationTimeout(sec);
 }
 
 void ConfigDialog::setVisibleDateTplEdit(bool checked)

--- a/src/core/ui/configwidget.h
+++ b/src/core/ui/configwidget.h
@@ -54,8 +54,6 @@ private slots:
     void currentItemChanged(const QModelIndex c ,const QModelIndex p);
     void editDateTmeTpl(const QString &str);
     void setVisibleDateTplEdit(bool);
-    void showNotification(bool show);
-    void changeNotificationTimeout(int sec);
     void setVisibleAutoSaveFirst(bool status);
     void changeFormatType(int type);
     void changeImgQualituSlider(int pos);

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -413,6 +413,16 @@ might become larger to fit to outer edges</string>
           </widget>
          </item>
          <item>
+          <widget class="QCheckBox" name="checkLastScreen">
+           <property name="toolTip">
+            <string>With multiple screens</string>
+           </property>
+           <property name="text">
+            <string>Remember last selected screen in next session</string>
+           </property>
+          </widget>
+         </item>
+         <item>
           <widget class="QGroupBox" name="checkNotify">
            <property name="title">
             <string>Notify on saving and copying</string>

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -83,8 +83,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
     _ui->toolBar->addAction(actQuit);
 
-    void (QSpinBox::*delayChange)(int) = &QSpinBox::valueChanged;
-    connect(_ui->delayBox, delayChange, this, &MainWindow::delayBoxChange);
+    connect(_ui->delayBox, &QSpinBox::valueChanged, this, &MainWindow::delayBoxChange);
     connect(_ui->cbxTypeScr, &QComboBox::currentIndexChanged, this, &MainWindow::typeScreenShotChange);
     connect(_ui->checkIncludeCursor, &QCheckBox::toggled, this, &MainWindow::checkIncludeCursor);
     connect(_ui->checkNoDecoration, &QCheckBox::toggled, this, &MainWindow::checkNoDecoration);
@@ -92,6 +91,12 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
     {
+        // Wayland does not support window screenshot for now.
+        // WARNING: If window shot becomes possible, change this and all occurrences of
+        // _ui->cbxTypeScr->setCurrentIndex as well as MainWindow::typeScreenShotChange
+        // in this file.
+        _ui->cbxTypeScr->removeItem(1);
+
         auto screens = QGuiApplication::screens();
         if (screens.size() > 1)
         {
@@ -104,7 +109,11 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
             });
             for (const auto &screen : std::as_const(screens))
                 _ui-> cbxScr->addItem(screen->name());
-            _ui-> cbxScr->setCurrentIndex(0);
+            _ui->cbxScr->setCurrentIndex(0);
+            connect(_ui->cbxScr, &QComboBox::currentTextChanged, this,
+                    [this] (const QString &text) {
+                _conf->setScreen(text);
+            });
         }
         else
         {
@@ -433,11 +442,32 @@ void MainWindow::delayBoxChange(int delay)
 
 void MainWindow::typeScreenShotChange(int type)
 {
-    _conf->setDefScreenshotType(type);
-    // show/hide checkboxes according to the type
-    _ui->checkNoDecoration->setVisible(type == 1 && QGuiApplication::platformName() != QStringLiteral("wayland"));
-    _ui->checkIncludeCursor->setVisible(type < 2);
-    _ui->checkZommMouseArea->setVisible(type >= 2 && QGuiApplication::platformName() != QStringLiteral("wayland"));
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        if (type == 0)
+        {
+            _conf->setDefScreenshotType(0); // fullscreen
+            _ui->checkIncludeCursor->setVisible(true);
+        }
+        else
+        {
+            _ui->checkIncludeCursor->setVisible(false);
+            if (type < 3)
+                _conf->setDefScreenshotType(type + 1);
+
+        }
+        _ui->checkNoDecoration->hide();
+        _ui->checkZommMouseArea->hide();
+    }
+    else
+    {
+        if (type < 4)
+            _conf->setDefScreenshotType(type);
+        // show/hide checkboxes according to the type
+        _ui->checkNoDecoration->setVisible(type == 1);
+        _ui->checkIncludeCursor->setVisible(type < 2);
+        _ui->checkZommMouseArea->setVisible(type >= 2);
+    }
 }
 
 void MainWindow::checkIncludeCursor(bool include)
@@ -461,11 +491,37 @@ void MainWindow::updateUI()
     _ui->delayBox->setValue(_conf->getDelay());
 
     int type = _conf->getDefScreenshotType();
-    _ui->cbxTypeScr->setCurrentIndex(type);
-    // show/hide checkboxes according to the type
-    _ui->checkNoDecoration->setVisible(type == 1 && QGuiApplication::platformName() != QStringLiteral("wayland"));
-    _ui->checkIncludeCursor->setVisible(type < 2);
-    _ui->checkZommMouseArea->setVisible(type >= 2 && QGuiApplication::platformName() != QStringLiteral("wayland"));
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        if (type < 2)
+        {
+            _ui->cbxTypeScr->setCurrentIndex(0);
+            _ui->checkIncludeCursor->setVisible(true);
+        }
+        else
+        {
+            _ui->checkIncludeCursor->setVisible(false);
+            if (type < 4)
+                _ui->cbxTypeScr->setCurrentIndex(type - 1);
+        }
+        _ui->checkNoDecoration->hide();
+        _ui->checkZommMouseArea->hide();
+
+        // if the last screen should be remembered, set up the combo-box
+        if (_conf->getRemLastScreen())
+            _ui->cbxScr->setCurrentText(_conf->getScreen());
+        // if the screen of the config file does not exist, correct it
+        _conf->setScreen(_ui->cbxScr->currentText());
+    }
+    else
+    {
+        if (type < 4)
+            _ui->cbxTypeScr->setCurrentIndex(type);
+        // show/hide checkboxes according to the type
+        _ui->checkNoDecoration->setVisible(type == 1);
+        _ui->checkIncludeCursor->setVisible(type < 2);
+        _ui->checkZommMouseArea->setVisible(type >= 2);
+    }
 
     _ui->checkZommMouseArea->setChecked(_conf->getZoomAroundMouse());
     _ui->checkNoDecoration->setChecked(_conf->getNoDecoration());
@@ -535,8 +591,16 @@ void MainWindow::showWindow(const QString& str)
     QString typeNum = str[str.size() - 1];
     int type = typeNum.toInt();
 
-    // change type scrren in config & on main window
-    _ui->cbxTypeScr->setCurrentIndex(type);
+    // change screenshot type in config & on main window
+    if (QGuiApplication::platformName() == QStringLiteral("wayland"))
+    {
+        if (type < 2)
+            _ui->cbxTypeScr->setCurrentIndex(0);
+        else if (type < 4)
+            _ui->cbxTypeScr->setCurrentIndex(type - 1);
+    }
+    else if (type < 4)
+        _ui->cbxTypeScr->setCurrentIndex(type);
     typeScreenShotChange(type);
 }
 

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -169,18 +169,25 @@ void MainWindow::closeEvent(QCloseEvent *e)
         actQuit->activate(QAction::Trigger);
 }
 
-// resize main window
-void MainWindow::resizeEvent(QResizeEvent *event)
+void MainWindow::fitPixmap()
 {
-    Q_UNUSED(event)
-    // get size dcreen pixel map
-    QSize scaleSize = Core::instance()->getPixmap()->size(); // get orig size pixmap
-
+    QSize scaleSize = Core::instance()->getPixmap()->size(); // orig pixmap size
     scaleSize.scale(_ui->scrLabel->contentsRect().size(), Qt::KeepAspectRatio);
-
     const QPixmap pixmap = _ui->scrLabel->pixmap(Qt::ReturnByValue);
     if (pixmap.isNull() || scaleSize != pixmap.size())
         updatePixmap(Core::instance()->getPixmap());
+}
+
+void MainWindow::resizeEvent(QResizeEvent *event)
+{
+    QMainWindow::resizeEvent(event);
+    fitPixmap();
+}
+
+void MainWindow::showEvent(QShowEvent *event)
+{
+    QMainWindow::showEvent(event);
+    fitPixmap();
 }
 
 bool MainWindow::eventFilter(QObject* obj, QEvent* event)

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -59,7 +59,8 @@ public Q_SLOTS:
 protected:
     void closeEvent(QCloseEvent *e);
     void changeEvent(QEvent *e);
-    void resizeEvent(QResizeEvent *event); // event resuze window
+    void resizeEvent(QResizeEvent *event);
+    void showEvent(QShowEvent *event);
     bool eventFilter(QObject *obj, QEvent *event);
 
 private:
@@ -85,6 +86,7 @@ private:
     void killTray();
     void disableTrayMenuActions(bool disable);
     void updateShortcuts();
+    void fitPixmap();
 
 private Q_SLOTS:
     void saveScreen();

--- a/src/core/ui/mainwindow.ui
+++ b/src/core/ui/mainwindow.ui
@@ -284,6 +284,9 @@
      <verstretch>0</verstretch>
     </sizepolicy>
    </property>
+   <property name="contextMenuPolicy">
+    <enum>Qt::PreventContextMenu</enum>
+   </property>
    <property name="windowTitle">
     <string>toolBar</string>
    </property>

--- a/src/core/wayland/ScreenShot.cpp
+++ b/src/core/wayland/ScreenShot.cpp
@@ -65,30 +65,33 @@ LXQt::Wayland::ScreenShot::ScreenShot(bool drawCursor, QScreen *screen, const QR
 
     wl_shm *shm = nullptr;
 
-    //qDebug() << "Using Wayland display:" << qDisplay->display();
-    //qDebug() << qDisplay->screens();
 
+    // NOTE: If there are persistent issues in detecting wlr_screencopy_manager_interface,
+    // then use a QEventLoop and wait for the QtWaylandClient::QWaylandDisplay::globalAdded
+    // to advertise the wlr_screencopy_manager_interface. The required code is commented out.
 
     // qDisplay->initialize();
 
     /*QEventLoop loop;
 
     QObject::connect(
-        qDisplay, &QtWaylandClient::QWaylandDisplay::globalAdded, [ &loop ] ( const QtWaylandClient::QWaylandDisplay::RegistryGlobal& global ) {
+        qDisplay, &QtWaylandClient::QWaylandDisplay::globalAdded, [ &loop ] (const QtWaylandClient::QWaylandDisplay::RegistryGlobal& global) {
             qDebug() << global.interface << "added";
 
-            if ( ( global.interface == zwlr_screencopy_manager_v1_interface.name ) && ( scrnCopyMgr == nullptr ) ) {
-                zwlr_screencopy_manager_v1 *wlrScreenCopyMgr = (zwlr_screencopy_manager_v1 *)wl_registry_bind( global.registry, global.id, &zwlr_screencopy_manager_v1_interface, 3 );
+            if ((global.interface == zwlr_screencopy_manager_v1_interface.name) && (scrnCopyMgr == nullptr))
+            {
+                zwlr_screencopy_manager_v1 *wlrScreenCopyMgr = (zwlr_screencopy_manager_v1 *)wl_registry_bind(global.registry, global.id, &zwlr_screencopy_manager_v1_interface, 3);
 
-                if ( wlrScreenCopyMgr ) {
+                if (wlrScreenCopyMgr)
+                {
                     scrnCopyMgr = new LXQt::Wayland::ScreenCopyManager( wlrScreenCopyMgr );
                 }
 
                 loop.quit();
             }
-
-            else if ( global.interface == wl_shm_interface.name ) {
-                shm = (wl_shm *)wl_registry_bind( global.registry, global.id, &wl_shm_interface, global.version );
+            else if (global.interface == wl_shm_interface.name)
+            {
+                shm = (wl_shm *)wl_registry_bind(global.registry, global.id, &wl_shm_interface, global.version);
             }
         }
     );*/
@@ -111,7 +114,8 @@ LXQt::Wayland::ScreenShot::ScreenShot(bool drawCursor, QScreen *screen, const QR
         }
     }
 
-    /*if ( ( scrnCopyMgr == nullptr ) || ( shm == nullptr ) ) {
+    /*if ((scrnCopyMgr == nullptr) || (shm == nullptr))
+    {
         loop.exec();
     }*/
 
@@ -157,7 +161,7 @@ LXQt::Wayland::ScreenShot::ScreenShot(bool drawCursor, QScreen *screen, const QR
         }
     });
 
-    QObject::connect(frame, &LXQt::Wayland::ScreenCopyFrame::ready, this, [this, screen]
+    QObject::connect(frame, &LXQt::Wayland::ScreenCopyFrame::ready, this, [this]
                      (LXQt::Wayland::ScreenFrameBuffer *buffer) {
         if (buffer == nullptr)
         {


### PR DESCRIPTION
The fitting option is made hidden and the window screenshot is removed under Wayland.

Also, a Wayland-only option is added to the Advanced page for remembering the last selected screen in the next session. It's unchecked by default because it may be confusing for some users.

NOTE: The screen combo-box is needed only because there's no way of knowing the screen with cursor under Wayland. At the current pace, this should be fixed by Wayland devs in the next century. Then I'll remove that combo-box and its corresponding option.