### PR TITLE
General GUI cleanup and two fixes

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -88,7 +88,7 @@ public:
         shortcutSave = 4,
         shortcutCopy = 5,
         shortcutOptions = 6,
-        shortcutHelp = 7,
+        shortcutHelp = 7, // FIXME: remove this
         shortcutClose = 8
     };
 

--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -150,6 +150,9 @@ void Core::sleep(int msec)
 
 void Core::coreQuit()
 {
+    if (_wnd && !_wnd->findChildren<QDialog*>().isEmpty())
+        return; // WARNING: quitting with a modal dialog causes crash
+
     _conf->setLastSelection(_lastSelectedArea);
     _conf->saveScreenshotSettings();
 
@@ -200,6 +203,15 @@ void Core::getFullScreenPixmap(QScreen* screen)
 // get screenshot
 void Core::screenShot(bool first)
 {
+    // WARNING: With a modal dialog, the mouse and keyboard can be blocked
+    // when an area screenshot is taken (e.g., by a global shortcut).
+    if (!_wnd->findChildren<QDialog*>().isEmpty()
+        && (_conf->getDefScreenshotType() == Core::Area
+            || _conf->getDefScreenshotType() == Core::PreviousSelection))
+    {
+        return;
+    }
+
     killTempFile(); // remove the old temp file if any
 
     if (QGuiApplication::platformName() != QStringLiteral("wayland"))

--- a/src/core/shortcutmanager.cpp
+++ b/src/core/shortcutmanager.cpp
@@ -61,8 +61,6 @@ void ShortcutManager::loadSettings()
                 Config::shortcutCopy, Config::localShortcut);
     setShortcut(_shortcutSettings->value(KEY_SHORTCUT_OPT, DEF_SHORTCUT_OPT).toString(),
                 Config::shortcutOptions, Config::localShortcut);
-    setShortcut(_shortcutSettings->value(KEY_SHORTCUT_HELP, DEF_SHORTCUT_HELP).toString(),
-                Config::shortcutHelp, Config::localShortcut);
     setShortcut(_shortcutSettings->value(KEY_SHORTCUT_CLOSE, DEF_SHORTCUT_CLOSE).toString(),
                 Config::shortcutClose, Config::localShortcut);
     _shortcutSettings->endGroup();
@@ -84,7 +82,6 @@ void ShortcutManager::saveSettings()
     _shortcutSettings->setValue(KEY_SHORTCUT_SAVE, getShortcut(Config::shortcutSave));
     _shortcutSettings->setValue(KEY_SHORTCUT_COPY, getShortcut(Config::shortcutCopy));
     _shortcutSettings->setValue(KEY_SHORTCUT_OPT, getShortcut(Config::shortcutOptions));
-    _shortcutSettings->setValue(KEY_SHORTCUT_HELP, getShortcut(Config::shortcutHelp));
     _shortcutSettings->setValue(KEY_SHORTCUT_CLOSE, getShortcut(Config::shortcutClose));
     _shortcutSettings->endGroup();
 
@@ -101,7 +98,6 @@ void ShortcutManager::setDefaultSettings()
     setShortcut(DEF_SHORTCUT_SAVE,Config::shortcutSave, Config::localShortcut);
     setShortcut(DEF_SHORTCUT_COPY,Config::shortcutCopy, Config::localShortcut);
     setShortcut(DEF_SHORTCUT_OPT,Config::shortcutOptions, Config::localShortcut);
-    setShortcut(DEF_SHORTCUT_HELP,Config::shortcutHelp, Config::localShortcut);
     setShortcut(DEF_SHORTCUT_CLOSE,Config::shortcutClose, Config::localShortcut);
 
     setShortcut(DEF_SHORTCUT_FULL,Config::shortcutFullScreen, Config::globalShortcut);

--- a/src/core/ui/about.cpp
+++ b/src/core/ui/about.cpp
@@ -108,7 +108,9 @@ QString AboutDialog::tabAbout()
         .arg(QLatin1String("http://www.gnu.org/licenses/old-licenses/gpl-2.0.html"));
     str += QLatin1String("<br><br>");
 
-    str += tr("Copyright &copy; 2009-2025, LXQt team");
+    str += tr("Copyright &copy; 2009-2013, Artem 'DOOMer' Galichkin");
+    str += QLatin1String("<br>");
+    str += tr("Copyright &copy; 2013-2025, LXQt team");
     return str;
 }
 
@@ -139,8 +141,8 @@ QString AboutDialog::tabThanks()
 
     str += QLatin1String("<b>") + tr("Special thanks to:") + QLatin1String("</b>");
     str += QLatin1String("<ul>");
-    str += QLatin1String("<li>") + QLatin1String("Artem Galichkin - DOOMer at GitHub (") + tr("for creating ScreenGrab") + QLatin1String(")</li>");
-    str += QLatin1String("<li>") + QLatin1String("Marcus Britanicus at GitHub (") + tr("for supporting wlr screencopy protocol") + QLatin1String(")</li>");
+    str += QLatin1String("<li>") + QLatin1String("Artem Galichkin - DOOMer @ GitHub (") + tr("for creating ScreenGrab") + QLatin1String(")</li>");
+    str += QLatin1String("<li>") + QLatin1String("Marcus Britanicus @ GitHub (") + tr("for supporting wlr screencopy protocol") + QLatin1String(")</li>");
 
     return str;
 }

--- a/src/core/ui/about.cpp
+++ b/src/core/ui/about.cpp
@@ -26,9 +26,8 @@ AboutDialog::AboutDialog(QWidget *parent):
     QDialog(parent),
     _ui(new Ui::aboutWidget)
 {
-    setWindowFlags(Qt::Dialog |  Qt::CustomizeWindowHint | Qt::WindowTitleHint | Qt::WindowCloseButtonHint | Qt::WindowSystemMenuHint);
-
     _ui->setupUi(this);
+    setObjectName(QStringLiteral("aboutDialog"));
     _ui->labAppName->setText(_ui->labAppName->text() + QStringLiteral(" <b>") + qApp->applicationVersion() + QStringLiteral("</b>"));
 
     _ui->labQtVer->setText(tr("using Qt %1").arg(QString::fromUtf8(qVersion())));
@@ -109,7 +108,7 @@ QString AboutDialog::tabAbout()
         .arg(QLatin1String("http://www.gnu.org/licenses/old-licenses/gpl-2.0.html"));
     str += QLatin1String("<br><br>");
 
-    str += tr("Copyright &copy; 2009-2013, Artem 'DOOMer' Galichkin");
+    str += tr("Copyright &copy; 2009-2025, LXQt team");
     return str;
 }
 
@@ -137,28 +136,11 @@ QString AboutDialog::tabHelpUs()
 QString AboutDialog::tabThanks()
 {
     QString str;
-    str += QLatin1String("<b>") + tr("Translate:") + QLatin1String("</b>");
-    str += QLatin1String("<br>");
-    str += tr(" Brazilian Portuguese translation")  + QLatin1String("<br>");
-    str += tr("Marcio Moraes") + QLatin1String(" &lt;marciopanto@gmail.com&gt;<br>");
-    str += QLatin1String("<br>");
-    str += tr(" Ukrainian translation") + QLatin1String("<br>");
-    str += tr("Gennadi Motsyo") + QLatin1String(" &lt;drool@altlinux.ru&gt;<br>");
-    str += QLatin1String("<br>");
-    str += tr(" Spanish translation") + QLatin1String("<br>");
-    str += tr("Burjans L García D") + QLatin1String(" &lt;burjans@gmail.com&gt;<br>");
-    str += QLatin1String("<br>");
-    str += tr(" Italian translation") + QLatin1String("<br>");
-    str += QLatin1String("speps &lt;dreamspepser@yahoo.it&gt;<br>");
-    str += QLatin1String("<br>");
 
-    str += QLatin1String("<b>") + tr("Testing:") + QLatin1String("</b>");
-    str += QLatin1String("<br>");
-    str += QLatin1String("Jerome Leclanche - ") + tr("Dual monitor support and other in Linux") + QLatin1String("<br>");
-    str += QLatin1String("Alexander Sokolov - ") + tr("Dual monitor support in Linux") + QLatin1String("<br>");
-    str += QLatin1String("Alexantia - ") + tr("win32-build [Windows XP and 7]") + QLatin1String("<br>");
-    str += QLatin1String("iNight - ") + tr("old win32-build [Windows Vista]") + QLatin1String("<br>");
-    str += QLatin1String("burjans - ") + tr("win32-build [Windows 7]") + QLatin1String("<br>");
+    str += QLatin1String("<b>") + tr("Special thanks to:") + QLatin1String("</b>");
+    str += QLatin1String("<ul>");
+    str += QLatin1String("<li>") + QLatin1String("Artem Galichkin - DOOMer at GitHub (") + tr("for creating ScreenGrab") + QLatin1String(")</li>");
+    str += QLatin1String("<li>") + QLatin1String("Marcus Britanicus at GitHub (") + tr("for supporting wlr screencopy protocol") + QLatin1String(")</li>");
 
     return str;
 }

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -73,7 +73,6 @@ private:
     QAction *actCopy;
     QAction *actOptions;
     QAction *actAbout;
-    QAction *actHelp;
     QAction *actQuit;
     Config *_conf;
     QMenu *_trayMenu;
@@ -90,7 +89,6 @@ private:
 
 private Q_SLOTS:
     void saveScreen();
-    void showHelp();
     void showOptions();
     void showAbout();
     void delayBoxChange(int);


### PR DESCRIPTION
The About button is shown instead of the Help menu, and the About dialog is updated.

Also, fixed two bugs:

 * A dangerous situation might happen, which blocked both mouse and keyboard if an area screenshot was taken with a global shortcut while a modal dialog was shown (don't test that before applying this PR!). Now an area screenshot is taken only when there's no modal dialog.
 * The command-line option `-r` was broken on Wayland.

Fixes https://github.com/lxqt/screengrab/issues/404