### PR TITLE
Fixed 2 old X11 bugs, side pane of Options dialog, and more

### DIFF
--- a/src/core/core.h
+++ b/src/core/core.h
@@ -64,9 +64,9 @@ class Core : public QObject
 
 public Q_SLOTS:
     void coreQuit();
-    void setScreen();
+    void newScreenshot();
 
-    void screenShot(bool first = false);
+    void screenShot(bool first = false, bool delayed = false);
     void autoSave();
 
 public:
@@ -122,11 +122,9 @@ private:
     bool checkExsistFile(const QString &path);
     QString copyFileNameToCliipboard(QString file);
     void sendNotify(const StateNotifyMessage& message);
-
     void getFullScreenPixmap(QScreen* screen);
-
-    void waylandScreenShot();
-    void showWaylandScreenshot(const QPixmap& pixmap);
+    void showScreenshot();
+    void waylandScreenShot(bool delayed);
 
     QPixmap *_pixelMap; // pixel map
     RegionSelect *_selector; // region grabber widget
@@ -145,6 +143,7 @@ private:
 
 private Q_SLOTS:
     void regionGrabbed(bool grabbed);
+    void takeWaylandAreaScreenshot(bool checkCursor = true);
 
 };
 

--- a/src/core/main.cpp
+++ b/src/core/main.cpp
@@ -20,16 +20,30 @@
 #include "core/core.h"
 #include "ui/mainwindow.h"
 
+#include <signal.h>
 #include <QDebug>
+
+void handleQuitSignals (const std::vector<int>& quitSignals)
+{ // a minimal signal handler
+    auto handler = [](int sig)->void {
+        Q_UNUSED(sig)
+        QCoreApplication::quit();
+    };
+    for (int sig : quitSignals)
+        signal (sig, handler);
+}
 
 int main(int argc, char *argv[])
 {
-    SingleApp scr(argc, argv, QStringLiteral(VERSION));
+    SingleApp scr(argc, argv, QString::fromUtf8(qgetenv("USER")) + QStringLiteral("-screengrab-") + QStringLiteral(VERSION));
     scr.setApplicationVersion(QStringLiteral(VERSION));
     scr.setOrganizationName(QStringLiteral("lxqt"));
     scr.setOrganizationDomain(QStringLiteral("lxqt-project.org"));
     scr.setApplicationName(QStringLiteral("screengrab"));
     scr.setDesktopFileName(QStringLiteral("screengrab"));
+
+    handleQuitSignals({SIGQUIT, SIGINT, SIGTERM, SIGHUP});
+
     Core *ScreenGrab = Core::instance();
     ScreenGrab->processCmdLineOpts(scr.arguments());
     // SingleApp should be initialized only after processing command-line options

--- a/src/core/ui/configwidget.cpp
+++ b/src/core/ui/configwidget.cpp
@@ -102,6 +102,10 @@ ConfigDialog::ConfigDialog(QWidget *parent) :
             _moduleWidgetNames << currentModWidget->objectName();
         }
     }
+
+    // resize the list widget to its content
+    _ui->listWidget->setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Expanding);
+    _ui->listWidget->setMaximumWidth(_ui->listWidget->sizeHintForColumn(0) + 2 * _ui->listWidget->frameWidth() + 4);
 }
 
 ConfigDialog::~ConfigDialog()

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -30,48 +30,6 @@
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QListWidget" name="listWidget">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>160</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>32</width>
-         <height>32</height>
-        </size>
-       </property>
-       <property name="textElideMode">
-        <enum>Qt::ElideNone</enum>
-       </property>
-       <property name="isWrapping" stdset="0">
-        <bool>false</bool>
-       </property>
-       <property name="resizeMode">
-        <enum>QListView::Adjust</enum>
-       </property>
-       <property name="viewMode">
-        <enum>QListView::ListMode</enum>
-       </property>
-       <property name="uniformItemSizes">
-        <bool>false</bool>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
        <item>
         <property name="text">
          <string>Main</string>

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -53,7 +53,7 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
     Core *c = Core::instance();
 
     connect(actQuit, &QAction::triggered, c, &Core::coreQuit);
-    connect(actNew, &QAction::triggered, c, &Core::setScreen);
+    connect(actNew, &QAction::triggered, c, &Core::newScreenshot);
     connect(actSave, &QAction::triggered, this, &MainWindow::saveScreen);
     connect(actCopy, &QAction::triggered, c, &Core::copyScreen);
     connect(actOptions, &QAction::triggered, this, &MainWindow::showOptions);
@@ -424,18 +424,11 @@ void MainWindow::typeScreenShotChange(int type)
 {
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
     {
+        _ui->checkIncludeCursor->setVisible(true);
         if (type == 0)
-        {
             _conf->setDefScreenshotType(0); // fullscreen
-            _ui->checkIncludeCursor->setVisible(true);
-        }
-        else
-        {
-            _ui->checkIncludeCursor->setVisible(false);
-            if (type < 3)
-                _conf->setDefScreenshotType(type + 1);
-
-        }
+        else if (type < 3)
+            _conf->setDefScreenshotType(type + 1);
         _ui->checkNoDecoration->hide();
         _ui->checkZommMouseArea->hide();
     }
@@ -473,17 +466,13 @@ void MainWindow::updateUI()
     int type = _conf->getDefScreenshotType();
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
     {
+        _ui->checkIncludeCursor->setVisible(true);
         if (type < 2)
         {
             _ui->cbxTypeScr->setCurrentIndex(0);
-            _ui->checkIncludeCursor->setVisible(true);
         }
-        else
-        {
-            _ui->checkIncludeCursor->setVisible(false);
-            if (type < 4)
-                _ui->cbxTypeScr->setCurrentIndex(type - 1);
-        }
+        else if (type < 4)
+            _ui->cbxTypeScr->setCurrentIndex(type - 1);
         _ui->checkNoDecoration->hide();
         _ui->checkZommMouseArea->hide();
 


### PR DESCRIPTION
First, sorry that I included several changes in a single PR. I didn't have time to make multiple PRs. These are the changes:

 1. The following bugs are fixed for X11:
    * When "Autosave screenshot" was checked but "Save first screenshot" was *not*, and when the screenshot type was "Screen Area", the first screenshot was saved.
    * With "Screen Area" as the type, the `-m` option made the app exit after taking the screenshot under X11.
 2. The side-pane of the Options dialog now fits to its content with all translations.
 3. A minimal signal handler is added, such that the app exits gracefully on being terminated.
 4. The username and "screengrab" are added to the names of the app's `tmp` files, for them to be distinguished from other similar `tmp` files and also for different users.
 5. With a delayed area screenshot on Wayland, the delay is applied *after* selecting the area. The reason is that a trasnparent overlay is used, and so, showing menus/tooltips and similar jobs are possible only after the selection.
 6. The option for including the mouse pointer is enabled with delayed area selections on Wayland.

Closes https://github.com/lxqt/screengrab/issues/406