### PR TITLE
Command-line option for saving and exiting without window

### DIFF
--- a/src/core/config.h
+++ b/src/core/config.h
@@ -88,8 +88,7 @@ public:
         shortcutSave = 4,
         shortcutCopy = 5,
         shortcutOptions = 6,
-        shortcutHelp = 7, // FIXME: remove this
-        shortcutClose = 8
+        shortcutClose = 7
     };
 
     Q_DECLARE_FLAGS(ShortcutAction, Actions)

--- a/src/core/core.h
+++ b/src/core/core.h
@@ -103,6 +103,7 @@ public:
     void processCmdLineOpts(const QStringList& arguments);
 
     bool runAsMinimized();
+    bool noWin();
 
     QString getSaveFilePath(const QString &format);
     QString getDateTimeFileName();
@@ -115,7 +116,7 @@ private:
 
     static Core *corePtr;
 
-    void checkAutoSave(bool first = false);
+    void checkAutoSave();
 
     void getActiveWindow();
     void grabCursor(int offsetX, int offsetY);

--- a/src/core/regionselect.cpp
+++ b/src/core/regionselect.cpp
@@ -274,13 +274,23 @@ void RegionSelect::drawRectSelection(QPainter &painter)
 
     if (QGuiApplication::platformName() == QStringLiteral("wayland"))
     {
-        QColor color = palette().color(QPalette::Active, QPalette::Highlight);
         painter.setClipRegion(_selectRect.toRect());
-        painter.setPen(color);
+        QColor color = palette().color(QPalette::Active, QPalette::Highlight);
         color.setAlpha(90);
-        painter.setBrush(color);
-        painter.drawRect(_selectRect.toRect().adjusted(0, 0, -1, -1));
-        painter.setPen(palette().color(QPalette::Active, QPalette::HighlightedText));
+        painter.setBrush(color); // background
+        color = palette().color(QPalette::Active, QPalette::HighlightedText);
+        color.setAlpha(110);
+        painter.setPen(color); // border
+        QRect selRect = _selectRect.toRect().adjusted(0, 0, -1, -1);
+#if (QT_VERSION >= QT_VERSION_CHECK(6,8,0))
+        // a workaround for artifacts under Wayland
+        auto origMode = painter.compositionMode();
+        painter.setCompositionMode(QPainter::CompositionMode_Clear);
+        painter.fillRect(selRect, Qt::transparent);
+        painter.setCompositionMode(origMode);
+#endif
+        painter.drawRect(selRect);
+        painter.setPen(palette().color(QPalette::Active, QPalette::HighlightedText)); // text
     }
     else
     {

--- a/src/core/shortcutmanager.cpp
+++ b/src/core/shortcutmanager.cpp
@@ -36,7 +36,6 @@ const QString KEY_SHORTCUT_NEW = QStringLiteral("NewScreen");
 const QString KEY_SHORTCUT_SAVE = QStringLiteral("SaveScreen");
 const QString KEY_SHORTCUT_COPY = QStringLiteral("CopyScreen");
 const QString KEY_SHORTCUT_OPT = QStringLiteral("Options");
-const QString KEY_SHORTCUT_HELP = QStringLiteral("Help");
 const QString KEY_SHORTCUT_CLOSE = QStringLiteral("Close");
 
 ShortcutManager::ShortcutManager(QSettings *settings) :
@@ -114,7 +113,7 @@ void ShortcutManager::setShortcut(const QString &key, int action, int type)
 
 QKeySequence ShortcutManager::getShortcut(int action)
 {
-    return QKeySequence(_listShortcuts[action].key);;
+    return QKeySequence(_listShortcuts[action].key);
 }
 
 int ShortcutManager::getShortcutType(int action)

--- a/src/core/ui/configwidget.ui
+++ b/src/core/ui/configwidget.ui
@@ -538,11 +538,6 @@ might become larger to fit to outer edges</string>
            </item>
            <item>
             <property name="text">
-             <string>Help</string>
-            </property>
-           </item>
-           <item>
-            <property name="text">
              <string>Quit</string>
             </property>
            </item>


### PR DESCRIPTION
It's `-n` or `--no-win` and can be used alongside other options or alone. If it's used alone, the screenshot type will be determined by the configuration. Of course, this option always saves the screenshot, regardless of the auto-save configuration.

Also,

 * The selection rectangle is made more visible by using the highlighted text color for its border.
 * The Help shortcut is removed from the code (Help was removed from GUI before).

Closes https://github.com/lxqt/screengrab/issues/407