### PR TITLE
No tray icon with `-n` and fixed window screen on X11

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -359,8 +359,8 @@ void Core::showScreenshot()
         QTimer::singleShot(0, this, &Core::coreQuit);
         return;
     }
+    _wnd->resize(_conf->getRestoredWndSize()); // before showing, to center the window on X11
     _wnd->restoreFromShot();
-    _wnd->resize(_conf->getRestoredWndSize());
     if (runAsMinimized())
     {
         if (_wnd->isTrayed())

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -38,7 +38,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
     _trayed = false;
 
     _trayIcon = nullptr;
-    _hideWnd = nullptr;
     _trayMenu = nullptr;
 
     // create actions menu
@@ -122,9 +121,15 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
     setWindowIcon(appIcon);
 
-    auto screens = QGuiApplication::screens();
-    const QRect geometry = screens.isEmpty() ? QRect() : screens.at(0)->availableGeometry();
-    move(geometry.width() / 2 - width() / 2, geometry.height() / 2 - height() / 2);
+    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
+    { // center the window on X11
+        auto screen = QGuiApplication::screenAt(QCursor::pos());
+        if (screen == nullptr)
+            screen = QGuiApplication::primaryScreen();
+        const QRect geometry = screen ? screen->availableGeometry() : QRect();
+        move(geometry.x() + (geometry.width() - width()) / 2,
+             geometry.y() + (geometry.height() - height()) / 2);
+    }
 
     _ui->scrLabel->installEventFilter(this);
     _ui->delayBox->installEventFilter(this);
@@ -149,7 +154,7 @@ void MainWindow::changeEvent(QEvent *e)
 
 void MainWindow::closeEvent(QCloseEvent *e)
 {
-    if (_conf->getCloseInTray() && _conf->getShowTrayIcon())
+    if (!Core::instance()->noWin() && _conf->getCloseInTray() && _conf->getShowTrayIcon())
     {
         if (findChildren<QDialog*>().isEmpty()) // do not hide with a modal dialog
             windowHideShow();
@@ -498,8 +503,8 @@ void MainWindow::updateUI()
 
     updateShortcuts();
 
-    // create tray object
-    if (_conf->getShowTrayIcon() && !_trayIcon)
+    // create tray object, but not with the "-n" option
+    if (!Core::instance()->noWin() && _conf->getShowTrayIcon() && !_trayIcon)
         createTray();
 
     // kill tray object, if tray was disabled in the configuration dialog
@@ -548,7 +553,7 @@ void MainWindow::windowHideShow()
 
 void MainWindow::hideToShot()
 {
-    if (_conf->getShowTrayIcon())
+    if (_trayIcon && _conf->getShowTrayIcon())
     {
         _trayIcon->blockSignals(true);
         disableTrayMenuActions(true);
@@ -586,7 +591,7 @@ void MainWindow::showWindow(const QString& str)
 
 void MainWindow::restoreFromShot()
 {
-    if (_conf->getShowTrayIcon())
+    if (_trayIcon && _conf->getShowTrayIcon())
     {
         _trayIcon->blockSignals(false);
         disableTrayMenuActions(false);

--- a/src/core/ui/mainwindow.cpp
+++ b/src/core/ui/mainwindow.cpp
@@ -121,16 +121,6 @@ MainWindow::MainWindow(QWidget* parent) : QMainWindow(parent),
 
     setWindowIcon(appIcon);
 
-    if (QGuiApplication::platformName() != QStringLiteral("wayland"))
-    { // center the window on X11
-        auto screen = QGuiApplication::screenAt(QCursor::pos());
-        if (screen == nullptr)
-            screen = QGuiApplication::primaryScreen();
-        const QRect geometry = screen ? screen->availableGeometry() : QRect();
-        move(geometry.x() + (geometry.width() - width()) / 2,
-             geometry.y() + (geometry.height() - height()) / 2);
-    }
-
     _ui->scrLabel->installEventFilter(this);
     _ui->delayBox->installEventFilter(this);
 }
@@ -181,6 +171,16 @@ void MainWindow::resizeEvent(QResizeEvent *event)
 
 void MainWindow::showEvent(QShowEvent *event)
 {
+    if (QGuiApplication::platformName() != QStringLiteral("wayland")
+        && !event->spontaneous())
+    { // center the window on X11
+        auto screen = QGuiApplication::screenAt(QCursor::pos());
+        if (screen == nullptr)
+            screen = QGuiApplication::primaryScreen();
+        const QRect geometry = screen ? screen->availableGeometry() : QRect();
+        move(geometry.x() + (geometry.width() - width()) / 2,
+             geometry.y() + (geometry.height() - height()) / 2);
+    }
     QMainWindow::showEvent(event);
     fitPixmap();
 }

--- a/src/core/ui/mainwindow.h
+++ b/src/core/ui/mainwindow.h
@@ -76,7 +76,6 @@ private:
     QAction *actQuit;
     Config *_conf;
     QMenu *_trayMenu;
-    QShortcut *_hideWnd;
     bool _trayed;
     QIcon appIcon;
 


### PR DESCRIPTION
Although a temporary tray icon is harmless, there's no reason to create and delete it.

Also, the code centered the main window on the first screen under X11. The patch centers it on the screen with cursor.

Closes https://github.com/lxqt/screengrab/issues/409