### PR TITLE
Better border color for selection rectangle on X11

### DIFF
--- a/src/core/regionselect.cpp
+++ b/src/core/regionselect.cpp
@@ -295,7 +295,7 @@ void RegionSelect::drawRectSelection(QPainter &painter)
     else
     {
         painter.drawPixmap(_selectRect, _desktopPixmapClr, pixmapRect(_selectRect));
-        painter.setPen(QPen(QBrush(QColor(0, 0, 0, 255)), 2));
+        painter.setPen(QPen(QBrush(QColor(255, 255, 255, 127)), 2));
         painter.drawRect(_selectRect);
     }
 


### PR DESCRIPTION
Since the whole area has a dark tint (black with 33% opacity), a white border with 50% opacity is used for the X11 selection. In this way, either the interior of the rectangle or its border is visible against all backgrounds.

Closes https://github.com/lxqt/screengrab/issues/373