### PR TITLE
Bug Fix: external edit not works with some Apps (especially Faltpak)

### DIFF
--- a/src/modules/extedit/extedit.cpp
+++ b/src/modules/extedit/extedit.cpp
@@ -48,9 +48,7 @@ void ExtEdit::runExternalEditor()
 
     QString editFilename = core->getTempFilename(format);
     core->writeScreen(editFilename, format, true);
-
-    QProcess::startDetached(action->desktopFile().expandExecString().first(),
-                            QStringList() << editFilename);
+    action->desktopFile().startDetached(QStringList() << editFilename);
     _watcherEditedFile->addPath(editFilename);
 }
 


### PR DESCRIPTION
### Bug Fix Description

This patch addresses the bug where the external editing function fails for certain applications, including, but not limited to, **Flatpak applications** .

Please see the related discussion in **Issue \#428**. This was a genuine bug but not an issue with the Flatpak application's packaging. It's unfortunate that the initial communication was insufficient, which led to the closure of it.

The core problem lies within the **`exitedit` module**. Tracing the execution using `strace` reveals that `exitedit` attempts to execute an incorrect external command:

```
[pid 27582] execve("/usr/bin/flatpak", ["/usr/bin/flatpak", "/tmp/screen"...], 0x7ffc155b2ed8 /* 112 vars */ <unfinished ...>
```

The original function implementation appears to only retain the first argument (index 0), which is the command name. This may work for some applications, but many others cannot be launched correctly by this way, including **all Flatpak apps** and even some regular applications.

The issue stems from an inappropriate mixing of the **Qt6 XDG** library functions and generic Qt library functions.

### Solution

The fix is simply to switch the implementation to use the specialized **`startDetached`** member function provided by the **Qt6 XDG** library (**`XdgDesktopFile::startDetached`**) instead of the generic **`QProcess::startDetached`**. Please refer to the code changes for the specific implementation details.

### Additional Note

As a side note, while this bug fix resolves the command execution issue, it does not completely solve all underlying problems with Flatpak applications. I have investigated the remaining issues and understand the necessary changes; I will work upon them when I have spare time.