### PR TITLE
bug fix: Position Error about env QT_SCALE_FACTOR

### DIFF
--- a/src/core/core.cpp
+++ b/src/core/core.cpp
@@ -331,7 +331,7 @@ void Core::takeWaylandAreaScreenshot(bool checkCursor)
         return;
     auto ws = new LXQt::Wayland::ScreenShot(checkCursor ? _conf->getIncludeCursor() : false,
                                             _wnd->selectedScreen(),
-                                            _selector->getSelectionRect(),
+                                            _selector->getSelectionRectScaled(),
                                             this);
     connect(ws, &LXQt::Wayland::ScreenShot::screenShotReady, this,
             [this, ws] (const QPixmap& pixmap) {

--- a/src/core/regionselect.cpp
+++ b/src/core/regionselect.cpp
@@ -15,6 +15,7 @@
  *   You should have received a copy of the GNU General Public License     *
  *   along with this program.  If not, see <http://www.gnu.org/licenses/>. *
  ***************************************************************************/
+#include <QDebug>
 
 #include "src/core/regionselect.h"
 
@@ -517,6 +518,24 @@ QRect RegionSelect::getSelectionRect() const
 
     QScreen *scr = _selectedScreen == nullptr ? qApp->primaryScreen() : _selectedScreen;
     return res.intersected(QRect(QPoint(0, 0), scr->size()));
+}
+
+QRect RegionSelect::getSelectionRectScaled() const
+{
+    // NOTE: "RegionSelect::getSelectionRect" have issue when QT_FACTOR_SCALE is not 1, some workaround here
+    qreal pixelRatio = _selectedScreen->devicePixelRatio();
+    QRectF res = getSelectionRect();
+    if ( pixelRatio != 1.0 ){
+        qreal tmpTop = res.top() * pixelRatio;
+        qreal tmpLeft = res.left() * pixelRatio;
+        qreal tmpBottom = res.bottom() * pixelRatio;
+        qreal tmpRight = res.right() * pixelRatio;
+        res.setTop(tmpTop);
+        res.setLeft(tmpLeft);
+        res.setBottom(tmpBottom);
+        res.setRight(tmpRight);
+    }
+    return res.toAlignedRect();
 }
 
 QPoint RegionSelect::getSelectionStartPos() const

--- a/src/core/regionselect.h
+++ b/src/core/regionselect.h
@@ -50,6 +50,7 @@ public:
 
     QPixmap getSelection() const;
     QRect getSelectionRect() const;
+    QRect getSelectionRectScaled() const;
     QPoint getSelectionStartPos() const;
 
 protected:


### PR DESCRIPTION
Currently, at least under **wlroots**, `screengrab` does not function correctly when the `QT_SCALE_FACTOR` environment variable is set to a value other than $1$. This results in a position offset for the captured screenshot.

While setting `QT_SCALE_FACTOR` is generally discouraged under Wayland, it proves useful in certain specific scenarios. Furthermore, ensuring that `screengrab` works properly across different environment variable settings is the correct approach.

I have implemented a **workaround** here, achieving the correct screenshot by manually applying a scaling adjustment. Although my approach might be considered inelegant, and a more graceful fix would be preferable, this modification has at least resolved the issue for me.

Thank you.